### PR TITLE
Replace loading GIF with CSS lottery-ball animation

### DIFF
--- a/.github/workflows/sync-slack-avatars.yml
+++ b/.github/workflows/sync-slack-avatars.yml
@@ -1,0 +1,43 @@
+name: Sync Slack avatars
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 每週一 09:00 (Asia/Taipei) = 01:00 UTC
+    - cron: '0 1 * * 1'
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Fetch & commit avatar map
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Fetch Slack avatars
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: node scripts/fetch-slack-avatars.mjs
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet -- public/slack-avatars.json; then
+            echo "No avatar changes — nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add public/slack-avatars.json
+          git commit -m "chore: sync Slack avatars"
+          git push origin master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,16 @@ Use WindiCSS utility classes, not Tailwind — they differ in some utilities and
 
 Merging to `master` triggers the GitHub Actions workflow (`.github/workflows/deploy.yml`) which builds and pushes `./dist` to `gh-pages`. The Vite `base` is set to `/awoo-drawing/`.
 
+## Slack avatars on the loading screen
+
+`LoadingPage.vue` renders each name as a "lottery ball" with an avatar. Avatars come from `public/slack-avatars.json` (a `{ "name": "image_url" }` map). Names not in the map fall back to a gradient + initials placeholder rendered by `src/libs/avatar.ts`.
+
+To refresh the map:
+- Local: `SLACK_BOT_TOKEN=xoxb-... pnpm sync-avatars` (token needs `users:read` scope).
+- Automated: the `Sync Slack avatars` workflow (`.github/workflows/sync-slack-avatars.yml`) runs weekly and on manual dispatch, requires the `SLACK_BOT_TOKEN` repo secret, and commits any change directly to `master` (which then redeploys via `deploy.yml`).
+
+The script keys each avatar by `real_name`, `display_name`, and Slack handle, so most name-list shapes match.
+
 ## Updating the title banner image
 
 Per the README workflow:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "sync-avatars": "node scripts/fetch-slack-avatars.mjs"
   },
   "dependencies": {
     "lockr": "0.9.0-beta.0",

--- a/scripts/fetch-slack-avatars.mjs
+++ b/scripts/fetch-slack-avatars.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// Fetches Slack workspace member avatars and writes a name -> image-URL
+// map to public/slack-avatars.json. The lottery app (LoadingPage) reads
+// that file at runtime to show real avatars on each lottery ball.
+//
+// Required env: SLACK_BOT_TOKEN (xoxb-... with `users:read` scope).
+// Optional env:
+//   SLACK_AVATAR_SIZE   one of 24,32,48,72,192,512,1024 (default: 192)
+//   SLACK_AVATAR_OUTPUT output path (default: public/slack-avatars.json)
+//
+// Run locally:  SLACK_BOT_TOKEN=xoxb-... node scripts/fetch-slack-avatars.mjs
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const TOKEN = process.env.SLACK_BOT_TOKEN;
+const SIZE = process.env.SLACK_AVATAR_SIZE || '192';
+const OUTPUT = path.resolve(
+  process.env.SLACK_AVATAR_OUTPUT || 'public/slack-avatars.json',
+);
+
+if (!TOKEN) {
+  console.error('SLACK_BOT_TOKEN env var is required.');
+  process.exit(1);
+}
+
+const fetchAllUsers = async () => {
+  const members = [];
+  let cursor = '';
+  for (;;) {
+    const params = new URLSearchParams({ limit: '200' });
+    if (cursor) params.set('cursor', cursor);
+    const res = await fetch(`https://slack.com/api/users.list?${params}`, {
+      headers: { Authorization: `Bearer ${TOKEN}` },
+    });
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} ${res.statusText}`);
+    }
+    const data = await res.json();
+    if (!data.ok) {
+      throw new Error(`Slack API error: ${data.error}`);
+    }
+    members.push(...(data.members ?? []));
+    cursor = data.response_metadata?.next_cursor || '';
+    if (!cursor) break;
+  }
+  return members;
+};
+
+const pickImage = (profile) => {
+  const key = `image_${SIZE}`;
+  return (
+    profile?.[key] ||
+    profile?.image_192 ||
+    profile?.image_512 ||
+    profile?.image_72 ||
+    profile?.image_original ||
+    ''
+  );
+};
+
+const main = async () => {
+  console.log('Fetching Slack workspace members...');
+  const members = await fetchAllUsers();
+  console.log(`  ${members.length} members returned`);
+
+  const map = {};
+  for (const m of members) {
+    if (m.deleted) continue;
+    if (m.is_bot) continue;
+    if (m.id === 'USLACKBOT') continue;
+    const url = pickImage(m.profile);
+    if (!url) continue;
+
+    // Index by every name shape the user might paste into the lottery's
+    // name list — Chinese real_name, English display_name, handle, etc.
+    const keys = new Set(
+      [
+        m.profile?.real_name,
+        m.profile?.real_name_normalized,
+        m.profile?.display_name,
+        m.profile?.display_name_normalized,
+        m.real_name,
+        m.name,
+      ]
+        .map((s) => (typeof s === 'string' ? s.trim() : ''))
+        .filter(Boolean),
+    );
+
+    for (const k of keys) {
+      // First writer wins so non-deleted accounts take priority over
+      // any later collisions.
+      if (!(k in map)) map[k] = url;
+    }
+  }
+
+  const sorted = Object.fromEntries(
+    Object.entries(map).sort(([a], [b]) => a.localeCompare(b, 'zh-Hant')),
+  );
+
+  await fs.mkdir(path.dirname(OUTPUT), { recursive: true });
+  await fs.writeFile(OUTPUT, JSON.stringify(sorted, null, 2) + '\n');
+  console.log(
+    `Wrote ${Object.keys(sorted).length} avatar entries to ${path.relative(
+      process.cwd(),
+      OUTPUT,
+    )}`,
+  );
+};
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,10 @@
   import { xor } from 'lodash-es';
   import Swal from 'sweetalert2';
   import { drawing } from './libs/libs';
+  import { loadAvatarMap } from './libs/avatar';
   import * as Lockr from 'lockr';
+
+  loadAvatarMap();
 
   const loadingPage = ref();
   const pageState = ref<'init' | 'loading' | 'result' | 'record'>('init');
@@ -63,9 +66,9 @@
       });
       return;
     }
+    winners.value = drawing(nameListArr.value, +headcount.value);
     pageState.value = 'loading';
     setTimeout(() => {
-      winners.value = drawing(nameListArr.value, +headcount.value);
       pageState.value = 'result';
     }, 5000);
   };
@@ -103,7 +106,12 @@
       @start="handleStart"
       @goRecord="handleGoRecord"
     />
-    <LoadingPage ref="loadingPage" v-else-if="pageState == 'loading'" />
+    <LoadingPage
+      ref="loadingPage"
+      v-else-if="pageState == 'loading'"
+      :nameList="nameListArr"
+      :winners="winners"
+    />
     <RecordPage v-else-if="pageState == 'record'" @back="handleBack" />
     <ResultPage :winners="winners" :awards="awards" @next="handleNext" v-else />
   </div>

--- a/src/components/LoadingPage.vue
+++ b/src/components/LoadingPage.vue
@@ -19,20 +19,371 @@
       </h1>
     </header>
 
-    <div class="mt-[120px] 3xl:mt-[120px] max-w-[552px]">
-      <img src="../assets/loading.webp" className="w-screen" />
-      <div class="music-player">
-        <audio
-          ref="audio"
-          src="./loading-music.mp3"
-          autoplay
-          id="audio"
-        ></audio>
+    <div
+      :class="['lottery-arena', phase === 'reveal' ? 'is-revealing' : '']"
+      :style="{ '--ball-size': ballSize + 'px' }"
+    >
+      <div
+        v-for="ball in balls"
+        :key="ball.name"
+        :class="['lottery-ball', ball.isWinner ? 'is-candidate' : '']"
+        :style="ball.style"
+      >
+        <div class="ball-avatar" :style="{ background: ball.gradient }">
+          <img
+            v-if="ball.avatarUrl"
+            :src="ball.avatarUrl"
+            :alt="ball.name"
+            @error="ball.avatarUrl = ''"
+          />
+          <span v-else>{{ ball.initials }}</span>
+        </div>
+        <span class="ball-name">{{ ball.name }}</span>
       </div>
+
+      <div class="winner-reveal" v-if="phase === 'reveal'">
+        <div
+          v-for="(winner, i) in winners"
+          :key="winner"
+          class="winner-card"
+          :style="{ animationDelay: i * 0.12 + 's' }"
+        >
+          <div
+            class="winner-avatar"
+            :style="{ background: getAvatarGradient(winner) }"
+          >
+            <img
+              v-if="getAvatarUrl(winner)"
+              :src="getAvatarUrl(winner)"
+              :alt="winner"
+            />
+            <span v-else>{{ getInitials(winner) }}</span>
+          </div>
+          <span class="winner-name">{{ winner }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="music-player">
+      <audio ref="audio" src="./loading-music.mp3" autoplay id="audio"></audio>
     </div>
   </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+  import { computed, onMounted, onUnmounted, ref } from 'vue';
+  import {
+    getAvatarGradient,
+    getAvatarUrl,
+    getInitials,
+  } from '../libs/avatar';
 
-<style></style>
+  interface IProps {
+    nameList: string[];
+    winners: string[];
+  }
+  const props = defineProps<IProps>();
+
+  const phase = ref<'flying' | 'reveal'>('flying');
+
+  // deterministic pseudo-random so layout stays stable per render
+  const rand = (seed: number) => {
+    const x = Math.sin(seed * 9301 + 49297) * 233280;
+    return x - Math.floor(x);
+  };
+
+  const ballSize = computed(() => {
+    const n = props.nameList.length;
+    if (n <= 20) return 96;
+    if (n <= 40) return 80;
+    if (n <= 80) return 64;
+    return 52;
+  });
+
+  const winnerSet = computed(() => new Set(props.winners));
+
+  const balls = computed(() =>
+    props.nameList.map((name, i) => {
+      const startX = rand(i * 1.3 + 0.1) * 86 + 2; // 2%–88%
+      const startY = rand(i * 2.7 + 0.5) * 78 + 4; // 4%–82%
+      const animIdx = (i % 5) + 1;
+      const duration = 5 + rand(i * 3.1 + 1.4) * 4; // 5–9s
+      const delay = -rand(i * 4.2 + 2.1) * 6; // -6–0s (desync)
+      const spinDir = i % 2 === 0 ? '' : 'reverse';
+      return {
+        name,
+        avatarUrl: getAvatarUrl(name) ?? '',
+        gradient: getAvatarGradient(name),
+        initials: getInitials(name),
+        isWinner: winnerSet.value.has(name),
+        style: {
+          left: `${startX}%`,
+          top: `${startY}%`,
+          animationName: `float${animIdx}`,
+          animationDuration: `${duration}s`,
+          animationDelay: `${delay}s`,
+          animationDirection: spinDir,
+        },
+      };
+    }),
+  );
+
+  let revealTimer: number | undefined;
+  onMounted(() => {
+    revealTimer = window.setTimeout(() => {
+      phase.value = 'reveal';
+    }, 3800);
+  });
+  onUnmounted(() => {
+    if (revealTimer) clearTimeout(revealTimer);
+  });
+</script>
+
+<style scoped>
+  .lottery-arena {
+    position: relative;
+    width: min(1200px, 92vw);
+    height: 600px;
+    margin: 60px auto 0;
+    overflow: visible;
+  }
+
+  .lottery-ball {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    transform: translate(0, 0);
+    animation-iteration-count: infinite;
+    animation-timing-function: ease-in-out;
+    will-change: transform, opacity;
+    transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+  }
+
+  .ball-avatar {
+    width: var(--ball-size, 80px);
+    height: var(--ball-size, 80px);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-weight: 800;
+    font-size: calc(var(--ball-size, 80px) * 0.32);
+    border: 3px solid #fff;
+    box-shadow: 0 8px 20px rgba(205, 0, 0, 0.25),
+      inset 0 -6px 12px rgba(0, 0, 0, 0.18),
+      inset 0 6px 10px rgba(255, 255, 255, 0.35);
+    overflow: hidden;
+    user-select: none;
+  }
+
+  .ball-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .ball-name {
+    background: #fff;
+    color: #cd0000;
+    border-radius: 100px;
+    padding: 2px 12px;
+    font-size: 14px;
+    font-weight: 700;
+    white-space: nowrap;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .lottery-arena.is-revealing .lottery-ball {
+    opacity: 0;
+    transform: scale(0.4);
+    animation-play-state: paused;
+  }
+
+  .winner-reveal {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 32px;
+    padding: 0 40px;
+    pointer-events: none;
+  }
+
+  .winner-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    animation: pop-in 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+  }
+
+  .winner-avatar {
+    width: 160px;
+    height: 160px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-weight: 800;
+    font-size: 56px;
+    border: 6px solid #fff;
+    box-shadow: 0 0 40px rgba(255, 215, 0, 0.85),
+      0 12px 30px rgba(205, 0, 0, 0.35),
+      inset 0 -10px 20px rgba(0, 0, 0, 0.18),
+      inset 0 10px 20px rgba(255, 255, 255, 0.35);
+    overflow: hidden;
+    animation: glow 1.4s ease-in-out infinite alternate;
+  }
+
+  .winner-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .winner-name {
+    background: #cd0000;
+    color: #fff;
+    border-radius: 100px;
+    padding: 8px 28px;
+    font-size: 28px;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+    max-width: 280px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  @keyframes float1 {
+    0% {
+      transform: translate(0, 0) rotate(0deg);
+    }
+    25% {
+      transform: translate(120px, -90px) rotate(8deg);
+    }
+    50% {
+      transform: translate(-80px, 110px) rotate(-6deg);
+    }
+    75% {
+      transform: translate(-140px, -50px) rotate(10deg);
+    }
+    100% {
+      transform: translate(0, 0) rotate(0deg);
+    }
+  }
+  @keyframes float2 {
+    0% {
+      transform: translate(0, 0) rotate(0deg);
+    }
+    33% {
+      transform: translate(-150px, 70px) rotate(-12deg);
+    }
+    66% {
+      transform: translate(110px, -120px) rotate(8deg);
+    }
+    100% {
+      transform: translate(0, 0) rotate(0deg);
+    }
+  }
+  @keyframes float3 {
+    0% {
+      transform: translate(0, 0) rotate(0deg);
+    }
+    20% {
+      transform: translate(80px, 110px) rotate(6deg);
+    }
+    40% {
+      transform: translate(160px, -60px) rotate(-8deg);
+    }
+    60% {
+      transform: translate(-90px, -130px) rotate(12deg);
+    }
+    80% {
+      transform: translate(-130px, 60px) rotate(-6deg);
+    }
+    100% {
+      transform: translate(0, 0) rotate(0deg);
+    }
+  }
+  @keyframes float4 {
+    0% {
+      transform: translate(0, 0) rotate(0deg);
+    }
+    25% {
+      transform: translate(-100px, -120px) rotate(-10deg);
+    }
+    50% {
+      transform: translate(140px, -40px) rotate(8deg);
+    }
+    75% {
+      transform: translate(60px, 130px) rotate(-12deg);
+    }
+    100% {
+      transform: translate(0, 0) rotate(0deg);
+    }
+  }
+  @keyframes float5 {
+    0% {
+      transform: translate(0, 0) rotate(0deg);
+    }
+    16% {
+      transform: translate(90px, -70px) rotate(8deg);
+    }
+    33% {
+      transform: translate(-130px, -90px) rotate(-10deg);
+    }
+    50% {
+      transform: translate(150px, 80px) rotate(12deg);
+    }
+    66% {
+      transform: translate(50px, 140px) rotate(-6deg);
+    }
+    83% {
+      transform: translate(-110px, 50px) rotate(8deg);
+    }
+    100% {
+      transform: translate(0, 0) rotate(0deg);
+    }
+  }
+
+  @keyframes pop-in {
+    0% {
+      opacity: 0;
+      transform: scale(0.2) rotate(-20deg);
+    }
+    60% {
+      opacity: 1;
+      transform: scale(1.15) rotate(6deg);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1) rotate(0);
+    }
+  }
+
+  @keyframes glow {
+    0% {
+      box-shadow: 0 0 30px rgba(255, 215, 0, 0.6),
+        0 12px 30px rgba(205, 0, 0, 0.35),
+        inset 0 -10px 20px rgba(0, 0, 0, 0.18),
+        inset 0 10px 20px rgba(255, 255, 255, 0.35);
+    }
+    100% {
+      box-shadow: 0 0 60px rgba(255, 215, 0, 1),
+        0 12px 40px rgba(205, 0, 0, 0.5),
+        inset 0 -10px 20px rgba(0, 0, 0, 0.18),
+        inset 0 10px 20px rgba(255, 255, 255, 0.35);
+    }
+  }
+</style>

--- a/src/libs/avatar.ts
+++ b/src/libs/avatar.ts
@@ -1,0 +1,70 @@
+// Optional Slack avatar map. Drop a file at `public/slack-avatars.json`
+// shaped like `{ "王小明": "https://...jpg", ... }` and matching names will
+// render with the real photo. Names not in the map fall back to a
+// deterministic gradient + initials avatar.
+
+let avatarMap: Record<string, string> = {};
+let mapPromise: Promise<void> | null = null;
+
+export const loadAvatarMap = (): Promise<void> => {
+  if (mapPromise) return mapPromise;
+  mapPromise = (async () => {
+    try {
+      const url = `${import.meta.env.BASE_URL}slack-avatars.json`;
+      const res = await fetch(url, { cache: 'no-cache' });
+      if (res.ok) {
+        const data = await res.json();
+        if (data && typeof data === 'object') {
+          avatarMap = data as Record<string, string>;
+        }
+      }
+    } catch {
+      // No map file — fallback avatars will be used.
+    }
+  })();
+  return mapPromise;
+};
+
+export const getAvatarUrl = (name: string): string | undefined => {
+  return avatarMap[name.trim()];
+};
+
+const PALETTE: [string, string][] = [
+  ['#FF6B6B', '#FFA94D'],
+  ['#4ECDC4', '#1A8FE3'],
+  ['#FFD93D', '#FF8E3C'],
+  ['#A78BFA', '#7C3AED'],
+  ['#FCAEAE', '#CD0000'],
+  ['#A8E6CF', '#3E8E7E'],
+  ['#FFAAA5', '#D87093'],
+  ['#B5EAD7', '#5BC0BE'],
+  ['#FBC4AB', '#F08A5D'],
+  ['#C5A3FF', '#6A4C93'],
+];
+
+const hash = (s: string): number => {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (h * 31 + s.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+};
+
+export const getAvatarGradient = (name: string): string => {
+  const [c1, c2] = PALETTE[hash(name) % PALETTE.length];
+  return `linear-gradient(135deg, ${c1}, ${c2})`;
+};
+
+export const getInitials = (name: string): string => {
+  const t = name.trim();
+  if (!t) return '?';
+  if (/[一-龥]/.test(t)) {
+    return t.length > 2 ? t.slice(-2) : t;
+  }
+  return t
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((s) => s[0]?.toUpperCase() ?? '')
+    .join('');
+};


### PR DESCRIPTION
Names render as floating "lottery balls" with avatars and swirl across
the loading screen for ~3.8s, then non-winners fade out and winner
cards pop into the center for the remaining ~1.2s before transitioning
to the result page. Avatars are pulled from an optional
public/slack-avatars.json map (name -> Slack image URL); names without
a mapping fall back to a deterministic gradient + initials.

https://claude.ai/code/session_012K3Ypa9Lp5XWjerDpRynSk