### PR TITLE
Make every page fit the viewport on phone/tablet/laptop

### DIFF
--- a/src/components/InitPage.vue
+++ b/src/components/InitPage.vue
@@ -1,66 +1,46 @@
 <template>
-  <div class="bg">
-    <img
-      src="../assets/bg-circle.png"
-      class="w-screen h-[80%] fixed bottom-0 left-0 z-0 2xl:bottom-[-5%] 3xl:bottom-[-16%]"
-    />
-    <img
-      src="../assets/coin-bg.png"
-      class="pt-[50px] pl-[68px] w-full h-full absolute bottom-0 left-0 z-0 overflow-hidden"
-    />
-    <img src="../assets/left.png" class="absolute left-10 bottom-30" />
-    <img src="../assets/right.png" class="absolute right-10 bottom-30" />
+  <div class="page">
+    <img src="../assets/bg-circle.png" class="bg-circle" />
+    <img src="../assets/left.png" class="deco deco-left" />
+    <img src="../assets/right.png" class="deco deco-right" />
 
-    <button
-      class="absolute z-40 right-10 top-10 text-red text-xl font-bold"
-      @click="$emit('goRecord')"
-    >
-      抽獎紀錄
-    </button>
-  </div>
+    <button class="record-btn" @click="$emit('goRecord')">抽獎紀錄</button>
 
-  <div
-    class="relative w-screen h-screen z-10 flex flex-col justify-center items-center gap-5"
-  >
-    <header class="flex flex-col justify-center items-center pb-2 absolute top-0">
-      <img
-        src="../assets/2026_bn.png"
-        alt=""
-        class="mt-5 mb-5 rounded-3xl shadow-3xl h-auto w-[1100px] max-w-[90vw]"
-      />
-    </header>
-    <div class="w-[650px] px-10 py-8 bg-[#c10d23ef] rounded-xl shadow-xl">
-      <div class="grid grid-cols-[1fr,200px] gap-5">
-        <input
-          class="bg-bg rounded-[100px] h-[51px] shadow-sm text-xl text-black px-6 outline-transparent outline-0 shadow-md"
-          placeholder="輸入獎項"
-          v-model="awards"
-        />
-        <input
-          type="number"
-          class="bg-bg border-0 rounded-[100px] shadow-md h-[51px] shadow-sm text-xl text-black px-6 outline-transparent outline-0 focus:(outline-0 border-0 ring-0)"
-          placeholder="輸入人數"
-          max="10"
-          min="1"
-          v-model="headcount"
-        />
-      </div>
-      <div class="text-left mt-5">
-        <div class="text-2xl font-semibold">
-          抽獎人數 {{ nameList.split('\n').filter((n) => n.trim()).length }} 人
+    <div class="content">
+      <header class="banner">
+        <img src="../assets/2026_bn.png" alt="" class="banner-img" />
+      </header>
+
+      <div class="form-card">
+        <div class="row">
+          <input
+            class="text-input"
+            placeholder="輸入獎項"
+            v-model="awards"
+          />
+          <input
+            type="number"
+            class="text-input"
+            placeholder="輸入人數"
+            max="20"
+            min="1"
+            v-model="headcount"
+          />
         </div>
-        <textarea
-          class="w-full mt-2 bg-bg border-0 rounded-[30px] shadow-md shadow-sm text-xl text-black p-3 outline-transparent outline-0 focus:(outline-0 border-0 ring-0) scrollbar-thin scrollbar-thumb-red scrollbar-track-bg scrollbar-thumb-rounded-xl"
-          placeholder="請貼上抽獎者名字，以斷行分開"
-          rows="8"
-          v-model="nameList"
-        ></textarea>
-        <button
-          @click="emit('start')"
-          class="mt-5 flex items-center justify-center gap-5 w-full bg-secondary-80 text-[28px] leading-8 py-4 rounded-[100px] hover:bg-secondary-100"
-        >
-          開始抽獎<img src="../assets/arrow-right.svg" />
-        </button>
+
+        <div class="namelist-block">
+          <div class="namelist-label">
+            抽獎人數 {{ nameCount }} 人
+          </div>
+          <textarea
+            class="namelist-input"
+            placeholder="請貼上抽獎者名字，以斷行分開"
+            v-model="nameList"
+          ></textarea>
+          <button class="start-btn" @click="emit('start')">
+            開始抽獎<img src="../assets/arrow-right.svg" />
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -98,7 +78,6 @@
       emit('update:headcount', headcount);
     },
   });
-
   const nameList = computed({
     get() {
       return props.nameList;
@@ -107,6 +86,218 @@
       emit('update:nameList', nameList);
     },
   });
+  const nameCount = computed(
+    () => props.nameList.split('\n').filter((n) => n.trim()).length,
+  );
 </script>
 
-<style></style>
+<style scoped>
+  .page {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    height: 100svh;
+    overflow: hidden;
+    color: #222;
+  }
+
+  .bg-circle {
+    position: absolute;
+    width: 100%;
+    bottom: -10%;
+    left: 0;
+    z-index: 0;
+    pointer-events: none;
+  }
+
+  .deco {
+    position: absolute;
+    z-index: 0;
+    pointer-events: none;
+    max-height: 26vh;
+    object-fit: contain;
+  }
+  .deco-left {
+    left: 2vw;
+    bottom: 4vh;
+  }
+  .deco-right {
+    right: 2vw;
+    bottom: 4vh;
+  }
+
+  .record-btn {
+    position: absolute;
+    z-index: 40;
+    right: clamp(12px, 3vw, 40px);
+    top: clamp(12px, 3vh, 40px);
+    color: #cd0000;
+    font-size: clamp(14px, 2vh, 20px);
+    font-weight: 700;
+    background: transparent;
+    border: 0;
+  }
+
+  .content {
+    position: relative;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: clamp(8px, 2vh, 24px) clamp(12px, 3vw, 32px);
+    box-sizing: border-box;
+    gap: clamp(8px, 2vh, 20px);
+  }
+
+  .banner {
+    flex-shrink: 0;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+  }
+  .banner-img {
+    width: min(1100px, 92vw);
+    max-height: 28vh;
+    height: auto;
+    object-fit: contain;
+    border-radius: clamp(12px, 2vh, 24px);
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+  }
+
+  .form-card {
+    width: min(650px, 94vw);
+    background: #c10d23ef;
+    border-radius: clamp(10px, 1.6vh, 16px);
+    padding: clamp(14px, 2.4vh, 30px) clamp(16px, 3vw, 40px);
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.22);
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    gap: clamp(10px, 1.6vh, 18px);
+    max-height: min(560px, 70vh);
+  }
+
+  .row {
+    display: grid;
+    grid-template-columns: 1fr min(180px, 38%);
+    gap: clamp(8px, 1.4vw, 18px);
+  }
+
+  .text-input {
+    background: #ffefef;
+    border: 0;
+    border-radius: 999px;
+    height: clamp(40px, 5.5vh, 51px);
+    padding: 0 clamp(14px, 2vw, 24px);
+    font-size: clamp(15px, 2vh, 20px);
+    color: #000;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+    outline: 0;
+    width: 100%;
+    box-sizing: border-box;
+  }
+  .text-input:focus {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+  }
+  /* hide spin buttons on number input */
+  .text-input[type='number']::-webkit-inner-spin-button,
+  .text-input[type='number']::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  .text-input[type='number'] {
+    -moz-appearance: textfield;
+  }
+
+  .namelist-block {
+    display: flex;
+    flex-direction: column;
+    gap: clamp(8px, 1.4vh, 14px);
+    text-align: left;
+    min-height: 0;
+  }
+
+  .namelist-label {
+    color: #fff;
+    font-size: clamp(16px, 2.4vh, 22px);
+    font-weight: 600;
+  }
+
+  .namelist-input {
+    width: 100%;
+    background: #ffefef;
+    border: 0;
+    border-radius: clamp(14px, 2vh, 28px);
+    padding: clamp(10px, 1.6vh, 14px);
+    font-size: clamp(14px, 1.9vh, 18px);
+    color: #000;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+    outline: 0;
+    resize: none;
+    min-height: clamp(80px, 18vh, 200px);
+    max-height: 28vh;
+    box-sizing: border-box;
+    font-family: inherit;
+  }
+  .namelist-input:focus {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+  }
+
+  .start-btn {
+    background: #4e4c4c;
+    color: #fff;
+    border: 0;
+    border-radius: 999px;
+    padding: clamp(10px, 1.6vh, 16px) 0;
+    font-size: clamp(18px, 2.6vh, 28px);
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: clamp(8px, 1.4vw, 18px);
+    transition: background 0.2s;
+    width: 100%;
+  }
+  .start-btn:hover {
+    background: #222;
+  }
+  .start-btn img {
+    height: clamp(16px, 2.4vh, 24px);
+    width: auto;
+  }
+
+  @media (max-width: 768px) {
+    .deco {
+      max-height: 14vh;
+      opacity: 0.5;
+    }
+    .banner-img {
+      max-height: 20vh;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .deco {
+      display: none;
+    }
+    .row {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* Short-screen laptops (e.g. 1366×768): keep banner small so the
+     whole form is reachable above the fold. */
+  @media (max-height: 720px) {
+    .banner-img {
+      max-height: 20vh;
+    }
+    .form-card {
+      max-height: 78vh;
+    }
+  }
+</style>

--- a/src/components/LoadingPage.vue
+++ b/src/components/LoadingPage.vue
@@ -1,65 +1,63 @@
 <template>
-  <div class="bg">
+  <div class="page">
     <img
       src="../assets/bg-circle.png"
-      class="w-full fixed bottom-0 left-0 z-0 2xl:bottom-[-5%] 3xl:bottom-[-20%]"
+      class="bg-circle"
     />
-    <img
-      src="../assets/coin-bg.png"
-      class="pt-[50px] pl-[68px] w-full h-full absolute bottom-0 left-0 z-0 overflow-hidden"
-    />
-    <img src="../assets/left.png" class="absolute left-10 bottom-30" />
-    <img src="../assets/right.png" class="absolute right-10 bottom-30" />
-  </div>
-  <div class="relative z-10">
-    <header class="flex flex-col justify-center items-center gap-5">
-      <img src="../assets/awooLogo.svg" alt="awoo logo" class="w-[86px]" />
-      <h1 class="font-extrabold text-6xl text-red tracking-[0.15em]">
-        阿物科技前進高雄
-      </h1>
-    </header>
+    <img src="../assets/left.png" class="deco deco-left" />
+    <img src="../assets/right.png" class="deco deco-right" />
 
-    <div
-      :class="['lottery-arena', phase === 'reveal' ? 'is-revealing' : '']"
-      :style="{ '--ball-size': ballSize + 'px' }"
-    >
+    <div class="content">
+      <header class="loading-header">
+        <img src="../assets/awooLogo.svg" alt="awoo logo" class="logo" />
+        <h1 class="title">阿物科技前進高雄</h1>
+      </header>
+
       <div
-        v-for="ball in balls"
-        :key="ball.name"
-        :class="['lottery-ball', ball.isWinner ? 'is-candidate' : '']"
-        :style="ball.style"
+        :class="['lottery-arena', phase === 'reveal' ? 'is-revealing' : '']"
+        :style="{ '--ball-size': ballSize + 'px' }"
       >
-        <div class="ball-avatar" :style="{ background: ball.gradient }">
-          <img
-            v-if="ball.avatarUrl"
-            :src="ball.avatarUrl"
-            :alt="ball.name"
-            @error="ball.avatarUrl = ''"
-          />
-          <span v-else>{{ ball.initials }}</span>
-        </div>
-        <span class="ball-name">{{ ball.name }}</span>
-      </div>
-
-      <div class="winner-reveal" v-if="phase === 'reveal'">
         <div
-          v-for="(winner, i) in winners"
-          :key="winner"
-          class="winner-card"
-          :style="{ animationDelay: i * 0.12 + 's' }"
+          v-for="ball in balls"
+          :key="ball.name"
+          class="lottery-ball"
+          :style="ball.style"
         >
-          <div
-            class="winner-avatar"
-            :style="{ background: getAvatarGradient(winner) }"
-          >
+          <div class="ball-avatar" :style="{ background: ball.gradient }">
             <img
-              v-if="getAvatarUrl(winner)"
-              :src="getAvatarUrl(winner)"
-              :alt="winner"
+              v-if="ball.avatarUrl"
+              :src="ball.avatarUrl"
+              :alt="ball.name"
+              @error="ball.avatarUrl = ''"
             />
-            <span v-else>{{ getInitials(winner) }}</span>
+            <span v-else>{{ ball.initials }}</span>
           </div>
-          <span class="winner-name">{{ winner }}</span>
+          <span class="ball-name">{{ ball.name }}</span>
+        </div>
+
+        <div class="winner-reveal" v-if="phase === 'reveal'">
+          <div
+            v-for="(winner, i) in winners"
+            :key="winner"
+            class="winner-card"
+            :style="{
+              animationDelay: i * 0.12 + 's',
+              '--card-w': winnerCardWidth,
+            }"
+          >
+            <div
+              class="winner-avatar"
+              :style="{ background: getAvatarGradient(winner) }"
+            >
+              <img
+                v-if="getAvatarUrl(winner)"
+                :src="getAvatarUrl(winner)"
+                :alt="winner"
+              />
+              <span v-else>{{ getInitials(winner) }}</span>
+            </div>
+            <span class="winner-name">{{ winner }}</span>
+          </div>
         </div>
       </div>
     </div>
@@ -86,7 +84,6 @@
 
   const phase = ref<'flying' | 'reveal'>('flying');
 
-  // deterministic pseudo-random so layout stays stable per render
   const rand = (seed: number) => {
     const x = Math.sin(seed * 9301 + 49297) * 233280;
     return x - Math.floor(x);
@@ -94,22 +91,31 @@
 
   const ballSize = computed(() => {
     const n = props.nameList.length;
-    if (n <= 20) return 96;
-    if (n <= 40) return 80;
-    if (n <= 80) return 64;
-    return 52;
+    if (n <= 12) return 96;
+    if (n <= 24) return 80;
+    if (n <= 48) return 64;
+    if (n <= 80) return 52;
+    return 44;
+  });
+
+  const winnerCardWidth = computed(() => {
+    const n = props.winners.length;
+    if (n <= 1) return 'min(360px, 80vw)';
+    if (n <= 3) return 'min(260px, 40vw)';
+    if (n <= 6) return 'min(200px, 30vw)';
+    return 'min(160px, 22vw)';
   });
 
   const winnerSet = computed(() => new Set(props.winners));
 
   const balls = computed(() =>
     props.nameList.map((name, i) => {
-      const startX = rand(i * 1.3 + 0.1) * 86 + 2; // 2%–88%
-      const startY = rand(i * 2.7 + 0.5) * 78 + 4; // 4%–82%
-      const animIdx = (i % 5) + 1;
-      const duration = 5 + rand(i * 3.1 + 1.4) * 4; // 5–9s
-      const delay = -rand(i * 4.2 + 2.1) * 6; // -6–0s (desync)
-      const spinDir = i % 2 === 0 ? '' : 'reverse';
+      const startX = rand(i * 1.3 + 0.1) * 84 + 3; // 3%–87%
+      const startY = rand(i * 2.7 + 0.5) * 76 + 5; // 5%–81%
+      const animIdx = (i % 6) + 1;
+      const duration = 4 + rand(i * 3.1 + 1.4) * 4; // 4–8s
+      const delay = -rand(i * 4.2 + 2.1) * 6; // -6–0s
+      const spinDir = i % 3 === 0 ? 'reverse' : 'normal';
       return {
         name,
         avatarUrl: getAvatarUrl(name) ?? '',
@@ -140,11 +146,81 @@
 </script>
 
 <style scoped>
+  .page {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    height: 100svh;
+    overflow: hidden;
+    color: #222;
+  }
+
+  .bg-circle {
+    position: absolute;
+    width: 100%;
+    bottom: -10%;
+    left: 0;
+    z-index: 0;
+    pointer-events: none;
+  }
+
+  .deco {
+    position: absolute;
+    z-index: 0;
+    pointer-events: none;
+    max-height: 30vh;
+    object-fit: contain;
+  }
+  .deco-left {
+    left: 2vw;
+    bottom: 5vh;
+  }
+  .deco-right {
+    right: 2vw;
+    bottom: 5vh;
+  }
+
+  .content {
+    position: relative;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    width: 100%;
+    height: 100%;
+    padding: clamp(12px, 3vh, 32px) clamp(12px, 3vw, 32px);
+    box-sizing: border-box;
+    gap: clamp(12px, 3vh, 28px);
+  }
+
+  .loading-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(6px, 1.2vh, 14px);
+    flex-shrink: 0;
+  }
+  .logo {
+    width: clamp(48px, 8vh, 86px);
+    height: auto;
+  }
+  .title {
+    font-weight: 800;
+    font-size: clamp(24px, 5vw, 60px);
+    line-height: 1.1;
+    letter-spacing: 0.15em;
+    color: #cd0000;
+    margin: 0;
+    text-align: center;
+  }
+
   .lottery-arena {
     position: relative;
-    width: min(1200px, 92vw);
-    height: 600px;
-    margin: 60px auto 0;
+    width: 100%;
+    flex: 1 1 auto;
+    min-height: 0;
+    max-width: 1400px;
     overflow: visible;
   }
 
@@ -156,9 +232,10 @@
     gap: 6px;
     transform: translate(0, 0);
     animation-iteration-count: infinite;
-    animation-timing-function: ease-in-out;
+    animation-timing-function: cubic-bezier(0.45, 0.05, 0.55, 0.95);
     will-change: transform, opacity;
     transition: opacity 0.5s ease-out, transform 0.5s ease-out;
+    pointer-events: none;
   }
 
   .ball-avatar {
@@ -189,12 +266,12 @@
     background: #fff;
     color: #cd0000;
     border-radius: 100px;
-    padding: 2px 12px;
-    font-size: 14px;
+    padding: 2px 10px;
+    font-size: clamp(11px, 1.4vw, 14px);
     font-weight: 700;
     white-space: nowrap;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-    max-width: 160px;
+    max-width: min(160px, 26vw);
     overflow: hidden;
     text-overflow: ellipsis;
   }
@@ -212,8 +289,8 @@
     align-items: center;
     justify-content: center;
     flex-wrap: wrap;
-    gap: 32px;
-    padding: 0 40px;
+    gap: clamp(12px, 3vw, 32px);
+    padding: 0 clamp(12px, 3vw, 40px);
     pointer-events: none;
   }
 
@@ -221,21 +298,22 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 14px;
+    gap: clamp(6px, 1.4vh, 14px);
+    width: var(--card-w, 200px);
     animation: pop-in 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
   }
 
   .winner-avatar {
-    width: 160px;
-    height: 160px;
+    width: clamp(80px, 16vh, 160px);
+    height: clamp(80px, 16vh, 160px);
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     color: #fff;
     font-weight: 800;
-    font-size: 56px;
-    border: 6px solid #fff;
+    font-size: clamp(28px, 5vh, 56px);
+    border: 5px solid #fff;
     box-shadow: 0 0 40px rgba(255, 215, 0, 0.85),
       0 12px 30px rgba(205, 0, 0, 0.35),
       inset 0 -10px 20px rgba(0, 0, 0, 0.18),
@@ -254,107 +332,77 @@
     background: #cd0000;
     color: #fff;
     border-radius: 100px;
-    padding: 8px 28px;
-    font-size: 28px;
+    padding: 6px 22px;
+    font-size: clamp(16px, 2.6vh, 28px);
     font-weight: 800;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.06em;
     box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
-    max-width: 280px;
+    max-width: 100%;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
   }
 
+  /* Chaotic flight paths — translate uses vw/vh so the spread scales
+     with viewport (small screens get smaller jumps automatically). */
   @keyframes float1 {
-    0% {
-      transform: translate(0, 0) rotate(0deg);
-    }
-    25% {
-      transform: translate(120px, -90px) rotate(8deg);
-    }
-    50% {
-      transform: translate(-80px, 110px) rotate(-6deg);
-    }
-    75% {
-      transform: translate(-140px, -50px) rotate(10deg);
-    }
-    100% {
-      transform: translate(0, 0) rotate(0deg);
-    }
+    0%   { transform: translate(0, 0) rotate(0deg) scale(1); }
+    14%  { transform: translate(7vw, -8vh) rotate(35deg) scale(1.04); }
+    28%  { transform: translate(-5vw, -11vh) rotate(-25deg) scale(0.96); }
+    42%  { transform: translate(9vw, 4vh) rotate(50deg) scale(1.06); }
+    57%  { transform: translate(-8vw, 9vh) rotate(-40deg) scale(0.94); }
+    71%  { transform: translate(5vw, -5vh) rotate(20deg) scale(1.02); }
+    85%  { transform: translate(-3vw, 10vh) rotate(-15deg) scale(0.98); }
+    100% { transform: translate(0, 0) rotate(0deg) scale(1); }
   }
   @keyframes float2 {
-    0% {
-      transform: translate(0, 0) rotate(0deg);
-    }
-    33% {
-      transform: translate(-150px, 70px) rotate(-12deg);
-    }
-    66% {
-      transform: translate(110px, -120px) rotate(8deg);
-    }
-    100% {
-      transform: translate(0, 0) rotate(0deg);
-    }
+    0%   { transform: translate(0, 0) rotate(0deg) scale(1); }
+    16%  { transform: translate(-6vw, 7vh) rotate(-30deg) scale(0.95); }
+    33%  { transform: translate(8vw, -9vh) rotate(45deg) scale(1.05); }
+    50%  { transform: translate(-9vw, -5vh) rotate(-50deg) scale(0.92); }
+    66%  { transform: translate(6vw, 10vh) rotate(25deg) scale(1.06); }
+    83%  { transform: translate(-4vw, -8vh) rotate(-20deg) scale(1); }
+    100% { transform: translate(0, 0) rotate(0deg) scale(1); }
   }
   @keyframes float3 {
-    0% {
-      transform: translate(0, 0) rotate(0deg);
-    }
-    20% {
-      transform: translate(80px, 110px) rotate(6deg);
-    }
-    40% {
-      transform: translate(160px, -60px) rotate(-8deg);
-    }
-    60% {
-      transform: translate(-90px, -130px) rotate(12deg);
-    }
-    80% {
-      transform: translate(-130px, 60px) rotate(-6deg);
-    }
-    100% {
-      transform: translate(0, 0) rotate(0deg);
-    }
+    0%   { transform: translate(0, 0) rotate(0deg); }
+    12%  { transform: translate(5vw, 8vh) rotate(20deg) scale(1.03); }
+    25%  { transform: translate(-7vw, 11vh) rotate(-30deg) scale(0.97); }
+    37%  { transform: translate(10vw, -4vh) rotate(40deg) scale(1.05); }
+    50%  { transform: translate(-6vw, -10vh) rotate(-50deg) scale(0.93); }
+    62%  { transform: translate(8vw, 6vh) rotate(25deg) scale(1.04); }
+    75%  { transform: translate(-9vw, -3vh) rotate(-35deg) scale(0.96); }
+    87%  { transform: translate(4vw, 9vh) rotate(15deg) scale(1.02); }
+    100% { transform: translate(0, 0) rotate(0deg) scale(1); }
   }
   @keyframes float4 {
-    0% {
-      transform: translate(0, 0) rotate(0deg);
-    }
-    25% {
-      transform: translate(-100px, -120px) rotate(-10deg);
-    }
-    50% {
-      transform: translate(140px, -40px) rotate(8deg);
-    }
-    75% {
-      transform: translate(60px, 130px) rotate(-12deg);
-    }
-    100% {
-      transform: translate(0, 0) rotate(0deg);
-    }
+    0%   { transform: translate(0, 0) rotate(0deg) scale(1); }
+    20%  { transform: translate(-7vw, -9vh) rotate(-40deg) scale(1.05); }
+    40%  { transform: translate(9vw, -3vh) rotate(30deg) scale(0.95); }
+    60%  { transform: translate(4vw, 11vh) rotate(-25deg) scale(1.07); }
+    80%  { transform: translate(-8vw, 5vh) rotate(50deg) scale(0.94); }
+    100% { transform: translate(0, 0) rotate(0deg) scale(1); }
   }
   @keyframes float5 {
-    0% {
-      transform: translate(0, 0) rotate(0deg);
-    }
-    16% {
-      transform: translate(90px, -70px) rotate(8deg);
-    }
-    33% {
-      transform: translate(-130px, -90px) rotate(-10deg);
-    }
-    50% {
-      transform: translate(150px, 80px) rotate(12deg);
-    }
-    66% {
-      transform: translate(50px, 140px) rotate(-6deg);
-    }
-    83% {
-      transform: translate(-110px, 50px) rotate(8deg);
-    }
-    100% {
-      transform: translate(0, 0) rotate(0deg);
-    }
+    0%   { transform: translate(0, 0) rotate(0deg) scale(1); }
+    11%  { transform: translate(6vw, -5vh) rotate(25deg) scale(1.04); }
+    22%  { transform: translate(-8vw, -7vh) rotate(-35deg) scale(0.94); }
+    33%  { transform: translate(10vw, 6vh) rotate(45deg) scale(1.06); }
+    44%  { transform: translate(-5vw, 11vh) rotate(-20deg) scale(0.97); }
+    55%  { transform: translate(7vw, -10vh) rotate(40deg) scale(1.05); }
+    66%  { transform: translate(-10vw, 4vh) rotate(-30deg) scale(0.93); }
+    77%  { transform: translate(3vw, 9vh) rotate(15deg) scale(1.02); }
+    88%  { transform: translate(-6vw, -3vh) rotate(-25deg) scale(0.99); }
+    100% { transform: translate(0, 0) rotate(0deg) scale(1); }
+  }
+  @keyframes float6 {
+    0%   { transform: translate(0, 0) rotate(0deg) scale(1); }
+    18%  { transform: translate(-9vw, 4vh) rotate(-45deg) scale(1.05); }
+    36%  { transform: translate(5vw, -10vh) rotate(35deg) scale(0.94); }
+    54%  { transform: translate(-3vw, 11vh) rotate(-30deg) scale(1.06); }
+    72%  { transform: translate(8vw, 3vh) rotate(50deg) scale(0.95); }
+    90%  { transform: translate(-6vw, -8vh) rotate(-15deg) scale(1.02); }
+    100% { transform: translate(0, 0) rotate(0deg) scale(1); }
   }
 
   @keyframes pop-in {
@@ -384,6 +432,22 @@
         0 12px 40px rgba(205, 0, 0, 0.5),
         inset 0 -10px 20px rgba(0, 0, 0, 0.18),
         inset 0 10px 20px rgba(255, 255, 255, 0.35);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .deco {
+      max-height: 18vh;
+      opacity: 0.6;
+    }
+    .ball-name {
+      padding: 1px 8px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .deco {
+      display: none;
     }
   }
 </style>

--- a/src/components/RecordPage.vue
+++ b/src/components/RecordPage.vue
@@ -1,44 +1,34 @@
 <template>
-  <div class="bg">
-    <img src="../assets/left.png" class="absolute left-10 bottom-30" />
-    <img src="../assets/right.png" class="absolute right-10 bottom-30" />
-  </div>
-  <div class="relative z-10 h-screen">
-    <header class="flex flex-col justify-center items-center gap-5 bg-bg">
-      <img src="../assets/awooLogo.svg" alt="awoo logo" class="w-[86px]" />
-      <h1
-        class="bg-red rounded-full px-15 py-5 text-[50px] leading-[65px] font-bold min-w-[300px]"
-      >
-        抽獎紀錄
-      </h1>
-    </header>
+  <div class="page">
+    <img src="../assets/left.png" class="deco deco-left" />
+    <img src="../assets/right.png" class="deco deco-right" />
 
-    <div class="w-[771px] mt-20">
-      <div
-        class="h-[400px] bg-[#FFD7D7] rounded-lg p-4 scrollbar-thin scrollbar-thumb-red scrollbar-track-bg scrollbar-thumb-rounded-xl"
-      >
+    <div class="content">
+      <header class="record-header">
+        <img src="../assets/awooLogo.svg" alt="awoo logo" class="logo" />
+        <h1 class="record-title">抽獎紀錄</h1>
+      </header>
+
+      <div class="record-list">
+        <div
+          v-if="records.length === 0"
+          class="record-empty"
+        >
+          目前沒有任何抽獎紀錄
+        </div>
         <div
           v-for="(record, index) in records"
           :key="`${record.awards}-${index}`"
-          class="grid grid-cols-[auto,1fr] text-left text-gray-900 text-xl border-b border-solid border-red p-2"
+          class="record-row"
         >
-          <div class="font-semibold">{{ record.awards }}：</div>
-          <div>{{ record.winners.join('、') }}</div>
+          <div class="record-award">{{ record.awards }}</div>
+          <div class="record-winners">{{ record.winners.join('、') }}</div>
         </div>
       </div>
-      <div class="flex justify-center gap-20">
-        <button
-          @click="$emit('back')"
-          class="mt-5 text-red text-[28px] leading-8 flex items-center justify-center gap-6 font-bold"
-        >
-          返回
-        </button>
-        <button
-          @click="handleClear"
-          class="mt-5 text-black text-[28px] leading-8 flex items-center justify-center gap-6 font-bold"
-        >
-          清除紀錄
-        </button>
+
+      <div class="actions">
+        <button class="action-btn back" @click="$emit('back')">返回</button>
+        <button class="action-btn clear" @click="handleClear">清除紀錄</button>
       </div>
     </div>
   </div>
@@ -50,7 +40,10 @@
   import Swal from 'sweetalert2';
 
   const records = computed(() => {
-    return Lockr.get('awardsStore', []);
+    return Lockr.get('awardsStore', []) as {
+      awards: string;
+      winners: string[];
+    }[];
   });
 
   const emit = defineEmits<{
@@ -75,4 +68,144 @@
   };
 </script>
 
-<style></style>
+<style scoped>
+  .page {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    height: 100svh;
+    overflow: hidden;
+    color: #222;
+  }
+
+  .deco {
+    position: absolute;
+    z-index: 0;
+    pointer-events: none;
+    max-height: 24vh;
+    object-fit: contain;
+  }
+  .deco-left {
+    left: 2vw;
+    bottom: 4vh;
+  }
+  .deco-right {
+    right: 2vw;
+    bottom: 4vh;
+  }
+
+  .content {
+    position: relative;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    padding: clamp(12px, 3vh, 28px) clamp(12px, 3vw, 32px);
+    box-sizing: border-box;
+    gap: clamp(10px, 2vh, 20px);
+  }
+
+  .record-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(6px, 1.2vh, 16px);
+    flex-shrink: 0;
+  }
+  .logo {
+    width: clamp(48px, 8vh, 86px);
+    height: auto;
+  }
+  .record-title {
+    background: #cd0000;
+    color: #fff;
+    border-radius: 999px;
+    padding: clamp(8px, 1.5vh, 16px) clamp(24px, 5vw, 60px);
+    font-size: clamp(22px, 4vh, 50px);
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    margin: 0;
+    box-shadow: inset -2px -4px 0 rgba(0, 0, 0, 0.25);
+    min-width: min(280px, 80vw);
+    text-align: center;
+  }
+
+  .record-list {
+    flex: 1 1 auto;
+    min-height: 0;
+    width: min(800px, 94vw);
+    background: #ffd7d7;
+    border-radius: clamp(8px, 1.4vh, 12px);
+    padding: clamp(10px, 1.6vh, 16px);
+    overflow-y: auto;
+    box-sizing: border-box;
+    box-shadow: 0 12px 30px rgba(205, 0, 0, 0.18);
+  }
+
+  .record-empty {
+    color: #4e4c4c;
+    font-size: clamp(14px, 2vh, 18px);
+    padding: clamp(20px, 6vh, 60px) 0;
+    text-align: center;
+  }
+
+  .record-row {
+    display: grid;
+    grid-template-columns: minmax(80px, max-content) 1fr;
+    gap: clamp(8px, 1.4vw, 16px);
+    align-items: baseline;
+    text-align: left;
+    color: #1a1a1a;
+    font-size: clamp(14px, 2vh, 20px);
+    border-bottom: 1px solid rgba(205, 0, 0, 0.45);
+    padding: clamp(6px, 1vh, 10px) clamp(2px, 0.6vw, 8px);
+  }
+  .record-row:last-child {
+    border-bottom: 0;
+  }
+
+  .record-award {
+    font-weight: 700;
+    color: #cd0000;
+  }
+
+  .record-winners {
+    word-break: break-word;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: center;
+    gap: clamp(20px, 6vw, 80px);
+    flex-shrink: 0;
+  }
+
+  .action-btn {
+    background: transparent;
+    border: 0;
+    font-size: clamp(18px, 2.6vh, 28px);
+    font-weight: 800;
+    padding: clamp(6px, 1vh, 10px) clamp(12px, 2vw, 20px);
+  }
+  .action-btn.back {
+    color: #cd0000;
+  }
+  .action-btn.clear {
+    color: #1a1a1a;
+  }
+
+  @media (max-width: 768px) {
+    .deco {
+      max-height: 14vh;
+      opacity: 0.4;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .deco {
+      display: none;
+    }
+  }
+</style>

--- a/src/components/ResultPage.vue
+++ b/src/components/ResultPage.vue
@@ -1,62 +1,350 @@
 <template>
-  <div class="bg">
-    <img src="../assets/left.png" class="absolute left-10 bottom-30" />
-    <img src="../assets/right.png" class="absolute right-10 bottom-30" />
-  </div>
-  <div class="relative z-10 h-screen">
-    <header class="flex flex-col justify-center items-center gap-5 bg-bg">
-      <img src="../assets/awooLogo.svg" alt="awoo logo" class="w-[86px]" />
-      <h1
-        class="bg-[#FFD7D7] px-15 py-2 text-[48px] leading-[48px] rounded-[100px] shadow-awards font-bold min-w-[400px]"
-      >
-        {{ awards }}
-      </h1>
-    </header>
+  <div class="page">
+    <img src="../assets/bg-circle.png" class="bg-circle" />
+    <img src="../assets/left.png" class="deco deco-left" />
+    <img src="../assets/right.png" class="deco deco-right" />
 
-    <div class="w-[1000px] mt-10">
-      <div class="text-[#4E4C4C] text-3xl mb-7">
-        得獎名單：共{{ winners.length }}位
-      </div>
-      <div class="min-h-[300px]">
-        <div
-          :class="`flex items-center justify-center flex-wrap ${
-            winners.length < 5 ? 'flex gap-10' : 'grid grid-cols-5 gap-5'
-          }`"
-        >
-          <span
-            :class="`bg-secondary-80 ${
-              winners.length < 3
-                ? 'text-[60px] leading-[95px] min-w-[448px] py-10'
-                : 'text-[20px] leading-[32px] min-w-[200px] py-3'
-            }  shadow-name rounded-[100px] px-[2px]`"
-            v-for="winner in winners"
+    <div class="content">
+      <header class="result-header">
+        <img src="../assets/awooLogo.svg" alt="awoo logo" class="logo" />
+        <h1 class="awards-badge">{{ awards }}</h1>
+      </header>
+
+      <div class="winners-area">
+        <div class="winners-count">
+          得獎名單：共 {{ winners.length }} 位
+        </div>
+        <div :class="['winners-grid', sizeClass]">
+          <div
+            v-for="(winner, i) in winners"
             :key="winner"
-            >{{ winner }}</span
+            class="winner-card"
+            :style="{ animationDelay: i * 0.08 + 's' }"
           >
+            <div
+              class="winner-avatar"
+              :style="{ background: getAvatarGradient(winner) }"
+            >
+              <img
+                v-if="getAvatarUrl(winner)"
+                :src="getAvatarUrl(winner)"
+                :alt="winner"
+                @error="onImgError"
+              />
+              <span v-else>{{ getInitials(winner) }}</span>
+            </div>
+            <span class="winner-name">{{ winner }}</span>
+          </div>
         </div>
       </div>
 
-      <button
-        @click="$emit('next')"
-        class="mt-5 text-red text-[28px] leading-8 flex items-center justify-center w-full gap-6 font-bold"
-      >
+      <button class="next-btn" @click="$emit('next')">
         下個獎項<img src="../assets/arrow-right-red.svg" />
       </button>
-      <div class="music-player">
-        <audio ref="audio" src="./result-music.mp3" autoplay id="audio"></audio>
-      </div>
+    </div>
+
+    <div class="music-player">
+      <audio ref="audio" src="./result-music.mp3" autoplay id="audio"></audio>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+  import { computed } from 'vue';
+  import {
+    getAvatarGradient,
+    getAvatarUrl,
+    getInitials,
+  } from '../libs/avatar';
+
   export interface IProps {
     winners: string[];
     awards: string;
   }
-  defineProps<IProps>();
+  const props = defineProps<IProps>();
 
   defineEmits(['next']);
+
+  const sizeClass = computed(() => {
+    const n = props.winners.length;
+    if (n <= 1) return 'size-xl';
+    if (n <= 3) return 'size-lg';
+    if (n <= 6) return 'size-md';
+    if (n <= 12) return 'size-sm';
+    return 'size-xs';
+  });
+
+  const onImgError = (e: Event) => {
+    (e.target as HTMLImageElement).style.display = 'none';
+  };
 </script>
 
-<style></style>
+<style scoped>
+  .page {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    height: 100svh;
+    overflow: hidden;
+    color: #222;
+  }
+
+  .bg-circle {
+    position: absolute;
+    width: 100%;
+    bottom: -10%;
+    left: 0;
+    z-index: 0;
+    pointer-events: none;
+    opacity: 0.6;
+  }
+
+  .deco {
+    position: absolute;
+    z-index: 0;
+    pointer-events: none;
+    max-height: 28vh;
+    object-fit: contain;
+  }
+  .deco-left {
+    left: 2vw;
+    bottom: 4vh;
+  }
+  .deco-right {
+    right: 2vw;
+    bottom: 4vh;
+  }
+
+  .content {
+    position: relative;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    padding: clamp(12px, 3vh, 28px) clamp(12px, 3vw, 32px);
+    box-sizing: border-box;
+    gap: clamp(10px, 2vh, 22px);
+  }
+
+  .result-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(6px, 1.2vh, 16px);
+    flex-shrink: 0;
+  }
+
+  .logo {
+    width: clamp(48px, 8vh, 86px);
+    height: auto;
+  }
+
+  .awards-badge {
+    background: linear-gradient(135deg, #ffd7d7 0%, #ffe8e8 100%);
+    color: #cd0000;
+    padding: clamp(8px, 1.5vh, 16px) clamp(20px, 4vw, 60px);
+    border-radius: 999px;
+    font-size: clamp(22px, 4.2vh, 48px);
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    margin: 0;
+    box-shadow: inset -2px -4px 0 rgba(206, 3, 33, 0.4),
+      0 12px 30px rgba(205, 0, 0, 0.18);
+    min-width: min(280px, 80vw);
+    text-align: center;
+  }
+
+  .winners-area {
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
+    max-width: 1200px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(10px, 2vh, 24px);
+  }
+
+  .winners-count {
+    color: #4e4c4c;
+    font-size: clamp(14px, 2.4vh, 26px);
+    font-weight: 600;
+  }
+
+  .winners-grid {
+    flex: 1 1 auto;
+    min-height: 0;
+    width: 100%;
+    display: grid;
+    place-content: center;
+    align-items: start;
+    gap: clamp(12px, 2.4vh, 28px);
+    padding: clamp(4px, 1vh, 12px);
+    overflow: auto;
+  }
+
+  /* Tier-based sizing keeps winners filling the visible area without
+     scroll for typical 1-12 person draws. */
+  .winners-grid.size-xl {
+    grid-template-columns: 1fr;
+  }
+  .winners-grid.size-lg {
+    grid-template-columns: repeat(auto-fit, minmax(min(260px, 80vw), 1fr));
+  }
+  .winners-grid.size-md {
+    grid-template-columns: repeat(auto-fit, minmax(min(200px, 40vw), 1fr));
+  }
+  .winners-grid.size-sm {
+    grid-template-columns: repeat(auto-fit, minmax(min(160px, 30vw), 1fr));
+  }
+  .winners-grid.size-xs {
+    grid-template-columns: repeat(auto-fit, minmax(min(120px, 22vw), 1fr));
+  }
+
+  .winner-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(6px, 1.2vh, 12px);
+    animation: card-pop 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+    padding: clamp(6px, 1.2vh, 12px);
+    background: rgba(255, 255, 255, 0.55);
+    backdrop-filter: blur(8px);
+    border-radius: clamp(14px, 2vh, 24px);
+    border: 1px solid rgba(205, 0, 0, 0.1);
+    box-shadow: 0 8px 24px rgba(205, 0, 0, 0.12);
+  }
+
+  .winner-avatar {
+    --size: var(--avatar-size, 110px);
+    width: var(--size);
+    height: var(--size);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-weight: 800;
+    font-size: calc(var(--size) * 0.32);
+    border: 4px solid #fff;
+    box-shadow: 0 0 24px rgba(255, 215, 0, 0.7),
+      0 8px 18px rgba(205, 0, 0, 0.3),
+      inset 0 -8px 16px rgba(0, 0, 0, 0.18),
+      inset 0 8px 14px rgba(255, 255, 255, 0.35);
+    overflow: hidden;
+    animation: glow 1.6s ease-in-out infinite alternate;
+  }
+
+  .winner-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .size-xl .winner-avatar {
+    --avatar-size: clamp(140px, 28vh, 240px);
+  }
+  .size-lg .winner-avatar {
+    --avatar-size: clamp(100px, 18vh, 180px);
+  }
+  .size-md .winner-avatar {
+    --avatar-size: clamp(80px, 14vh, 130px);
+  }
+  .size-sm .winner-avatar {
+    --avatar-size: clamp(64px, 10vh, 100px);
+  }
+  .size-xs .winner-avatar {
+    --avatar-size: clamp(48px, 8vh, 80px);
+  }
+
+  .winner-name {
+    background: #cd0000;
+    color: #fff;
+    border-radius: 999px;
+    padding: clamp(4px, 0.8vh, 10px) clamp(14px, 2.4vw, 26px);
+    font-size: clamp(14px, 2.2vh, 22px);
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    box-shadow: inset -2px -3px 0 rgba(0, 0, 0, 0.25),
+      0 6px 14px rgba(205, 0, 0, 0.3);
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .size-xl .winner-name {
+    font-size: clamp(20px, 4vh, 36px);
+    padding: clamp(8px, 1.2vh, 14px) clamp(20px, 3vw, 40px);
+  }
+
+  .next-btn {
+    flex-shrink: 0;
+    color: #cd0000;
+    background: transparent;
+    border: 0;
+    font-size: clamp(18px, 2.6vh, 28px);
+    font-weight: 800;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: clamp(6px, 1vh, 12px) 24px;
+    transition: transform 0.2s ease;
+  }
+  .next-btn:hover {
+    transform: translateX(4px);
+  }
+  .next-btn img {
+    width: clamp(20px, 2.6vh, 28px);
+    height: auto;
+  }
+
+  @keyframes card-pop {
+    0% {
+      opacity: 0;
+      transform: translateY(30px) scale(0.7);
+    }
+    60% {
+      opacity: 1;
+      transform: translateY(-4px) scale(1.06);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0) scale(1);
+    }
+  }
+
+  @keyframes glow {
+    0% {
+      box-shadow: 0 0 20px rgba(255, 215, 0, 0.5),
+        0 8px 18px rgba(205, 0, 0, 0.3),
+        inset 0 -8px 16px rgba(0, 0, 0, 0.18),
+        inset 0 8px 14px rgba(255, 255, 255, 0.35);
+    }
+    100% {
+      box-shadow: 0 0 36px rgba(255, 215, 0, 0.95),
+        0 8px 22px rgba(205, 0, 0, 0.45),
+        inset 0 -8px 16px rgba(0, 0, 0, 0.18),
+        inset 0 8px 14px rgba(255, 255, 255, 0.35);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .deco {
+      max-height: 16vh;
+      opacity: 0.4;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .deco {
+      display: none;
+    }
+    .winners-grid {
+      gap: 12px;
+    }
+  }
+</style>

--- a/src/style.css
+++ b/src/style.css
@@ -1,7 +1,7 @@
 :root {
   font-family: Work Sans, Inter, Avenir, Helvetica, Arial, sans-serif;
   font-size: 16px;
-  line-height: 24px;
+  line-height: 1.5;
   font-weight: 400;
   color: white;
   background-color: white;
@@ -10,7 +10,32 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   -webkit-text-size-adjust: 100%;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  /* small viewport units keep iOS Safari's bottom bar from clipping content */
+  height: 100vh;
+  height: 100svh;
+  overflow: hidden;
   background: #ffefef;
+  overscroll-behavior: none;
+  touch-action: manipulation;
+}
+
+body {
+  min-width: 320px;
+}
+
+#app {
+  width: 100vw;
+  height: 100vh;
+  height: 100svh;
+  margin: 0 auto;
+  text-align: center;
   overflow: hidden;
 }
 
@@ -23,17 +48,11 @@ a:hover {
   color: #535bf2;
 }
 
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+button {
+  cursor: pointer;
 }
 
-#app {
-  max-width: 100vw;
-  max-height: 100vh;
-  margin: 0 auto;
-  text-align: center;
+input,
+textarea {
+  font-family: inherit;
 }
-


### PR DESCRIPTION
## Summary

- **Lottery balls 飛得更亂、更自然縮放**：6 條飛行路徑、每條 6–9 個關鍵點，translate 用 `vw`/`vh` 而非寫死像素 — 桌機看起來幅度更狂、手機自動縮小不會飛出畫面；外加 ±50° 旋轉、0.92↔1.06 scale 呼吸感、1/3 的球反向飛。
- **抽獎結果頁重做**：每位得獎人變成圓形大頭像 + 金光呼吸光暈 + 紅底白字徽章，依人數切五階尺寸（1 / 2-3 / 4-6 / 7-12 / 13+ 人），grid 用 `auto-fit` 排版，從一個頭獎到 20 人團體獎都不破版。
- **全站 RWD**：每頁改成 `flex column` 撐滿 `100svh`（解 iOS Safari 底部 bar 切內容），字級/間距/圓角全部用 `clamp(min, preferred, max)` 自動縮放；手機（≤480px）兔子裝飾隱藏、表單欄位改上下排；小筆電（高 ≤720px）banner 自動壓矮確保按鈕可達。
- **彩球 / 得獎卡片在可視範圍看得完**：Loading arena 用 `flex: 1` 撐滿剩餘空間，多人時球縮到 44px，80+ 人也排得下；Result grid 在 13+ 人切到最小卡片，全部塞進可視區。

## Test plan

- [ ] iPhone Safari（地址列 + 底部 bar 同時顯示）：開始抽獎、下個獎項按鈕都按得到，沒被 bar 切掉
- [ ] iPad 直立：banner + 表單垂直排得下、得獎卡片排成 2 欄
- [ ] 1366×720 小筆電：抽獎時所有彩球在可見範圍內飛動、不會超出
- [ ] 1920+ 大螢幕：彩球飛行幅度看起來夠狂、不會太小家子氣
- [ ] 抽 1 人 / 3 人 / 8 人 / 15 人 各跑一次，確認得獎卡片大小切換正確
- [ ] 抽獎紀錄頁與清除確認流程正常

https://claude.ai/code/session_012K3Ypa9Lp5XWjerDpRynSk

---
_Generated by [Claude Code](https://claude.ai/code/session_012K3Ypa9Lp5XWjerDpRynSk)_