### PR TITLE
Fix lottery balls invisible / static on iOS Safari

### DIFF
--- a/src/components/LoadingPage.vue
+++ b/src/components/LoadingPage.vue
@@ -183,10 +183,9 @@
   .content {
     position: relative;
     z-index: 10;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: flex-start;
+    display: grid;
+    grid-template-rows: auto 1fr;
+    justify-items: center;
     width: 100%;
     height: 100%;
     padding: clamp(12px, 3vh, 32px) clamp(12px, 3vw, 32px);
@@ -199,7 +198,6 @@
     flex-direction: column;
     align-items: center;
     gap: clamp(6px, 1.2vh, 14px);
-    flex-shrink: 0;
   }
   .logo {
     width: clamp(48px, 8vh, 86px);
@@ -218,8 +216,10 @@
   .lottery-arena {
     position: relative;
     width: 100%;
-    flex: 1 1 auto;
-    min-height: 0;
+    height: 100%;
+    /* defensive — guarantees absolute-positioned balls have a non-zero
+       containing block even if a browser collapses the grid track. */
+    min-height: 240px;
     max-width: 1400px;
     overflow: visible;
   }

--- a/src/components/LoadingPage.vue
+++ b/src/components/LoadingPage.vue
@@ -343,66 +343,69 @@
     white-space: nowrap;
   }
 
-  /* Chaotic flight paths — translate uses vw/vh so the spread scales
-     with viewport (small screens get smaller jumps automatically). */
+  /* translate3d forces a GPU compositor layer so the animation keeps
+     running smoothly under iOS Low Power Mode and avoids jank from
+     repaint. Magnitudes are px (not vw/vh) because iOS Safari has
+     historically evaluated viewport units inside @keyframes
+     inconsistently. */
   @keyframes float1 {
-    0%   { transform: translate(0, 0) rotate(0deg) scale(1); }
-    14%  { transform: translate(7vw, -8vh) rotate(35deg) scale(1.04); }
-    28%  { transform: translate(-5vw, -11vh) rotate(-25deg) scale(0.96); }
-    42%  { transform: translate(9vw, 4vh) rotate(50deg) scale(1.06); }
-    57%  { transform: translate(-8vw, 9vh) rotate(-40deg) scale(0.94); }
-    71%  { transform: translate(5vw, -5vh) rotate(20deg) scale(1.02); }
-    85%  { transform: translate(-3vw, 10vh) rotate(-15deg) scale(0.98); }
-    100% { transform: translate(0, 0) rotate(0deg) scale(1); }
+    0%   { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
+    14%  { transform: translate3d(95px, -75px, 0) rotate(35deg) scale(1.04); }
+    28%  { transform: translate3d(-72px, -105px, 0) rotate(-25deg) scale(0.96); }
+    42%  { transform: translate3d(120px, 55px, 0) rotate(50deg) scale(1.06); }
+    57%  { transform: translate3d(-105px, 95px, 0) rotate(-40deg) scale(0.94); }
+    71%  { transform: translate3d(72px, -55px, 0) rotate(20deg) scale(1.02); }
+    85%  { transform: translate3d(-45px, 105px, 0) rotate(-15deg) scale(0.98); }
+    100% { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
   }
   @keyframes float2 {
-    0%   { transform: translate(0, 0) rotate(0deg) scale(1); }
-    16%  { transform: translate(-6vw, 7vh) rotate(-30deg) scale(0.95); }
-    33%  { transform: translate(8vw, -9vh) rotate(45deg) scale(1.05); }
-    50%  { transform: translate(-9vw, -5vh) rotate(-50deg) scale(0.92); }
-    66%  { transform: translate(6vw, 10vh) rotate(25deg) scale(1.06); }
-    83%  { transform: translate(-4vw, -8vh) rotate(-20deg) scale(1); }
-    100% { transform: translate(0, 0) rotate(0deg) scale(1); }
+    0%   { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
+    16%  { transform: translate3d(-80px, 65px, 0) rotate(-30deg) scale(0.95); }
+    33%  { transform: translate3d(110px, -85px, 0) rotate(45deg) scale(1.05); }
+    50%  { transform: translate3d(-115px, -50px, 0) rotate(-50deg) scale(0.92); }
+    66%  { transform: translate3d(80px, 100px, 0) rotate(25deg) scale(1.06); }
+    83%  { transform: translate3d(-55px, -75px, 0) rotate(-20deg) scale(1); }
+    100% { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
   }
   @keyframes float3 {
-    0%   { transform: translate(0, 0) rotate(0deg); }
-    12%  { transform: translate(5vw, 8vh) rotate(20deg) scale(1.03); }
-    25%  { transform: translate(-7vw, 11vh) rotate(-30deg) scale(0.97); }
-    37%  { transform: translate(10vw, -4vh) rotate(40deg) scale(1.05); }
-    50%  { transform: translate(-6vw, -10vh) rotate(-50deg) scale(0.93); }
-    62%  { transform: translate(8vw, 6vh) rotate(25deg) scale(1.04); }
-    75%  { transform: translate(-9vw, -3vh) rotate(-35deg) scale(0.96); }
-    87%  { transform: translate(4vw, 9vh) rotate(15deg) scale(1.02); }
-    100% { transform: translate(0, 0) rotate(0deg) scale(1); }
+    0%   { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
+    12%  { transform: translate3d(70px, 80px, 0) rotate(20deg) scale(1.03); }
+    25%  { transform: translate3d(-90px, 110px, 0) rotate(-30deg) scale(0.97); }
+    37%  { transform: translate3d(125px, -45px, 0) rotate(40deg) scale(1.05); }
+    50%  { transform: translate3d(-80px, -100px, 0) rotate(-50deg) scale(0.93); }
+    62%  { transform: translate3d(105px, 65px, 0) rotate(25deg) scale(1.04); }
+    75%  { transform: translate3d(-115px, -35px, 0) rotate(-35deg) scale(0.96); }
+    87%  { transform: translate3d(55px, 90px, 0) rotate(15deg) scale(1.02); }
+    100% { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
   }
   @keyframes float4 {
-    0%   { transform: translate(0, 0) rotate(0deg) scale(1); }
-    20%  { transform: translate(-7vw, -9vh) rotate(-40deg) scale(1.05); }
-    40%  { transform: translate(9vw, -3vh) rotate(30deg) scale(0.95); }
-    60%  { transform: translate(4vw, 11vh) rotate(-25deg) scale(1.07); }
-    80%  { transform: translate(-8vw, 5vh) rotate(50deg) scale(0.94); }
-    100% { transform: translate(0, 0) rotate(0deg) scale(1); }
+    0%   { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
+    20%  { transform: translate3d(-95px, -90px, 0) rotate(-40deg) scale(1.05); }
+    40%  { transform: translate3d(115px, -35px, 0) rotate(30deg) scale(0.95); }
+    60%  { transform: translate3d(60px, 110px, 0) rotate(-25deg) scale(1.07); }
+    80%  { transform: translate3d(-100px, 55px, 0) rotate(50deg) scale(0.94); }
+    100% { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
   }
   @keyframes float5 {
-    0%   { transform: translate(0, 0) rotate(0deg) scale(1); }
-    11%  { transform: translate(6vw, -5vh) rotate(25deg) scale(1.04); }
-    22%  { transform: translate(-8vw, -7vh) rotate(-35deg) scale(0.94); }
-    33%  { transform: translate(10vw, 6vh) rotate(45deg) scale(1.06); }
-    44%  { transform: translate(-5vw, 11vh) rotate(-20deg) scale(0.97); }
-    55%  { transform: translate(7vw, -10vh) rotate(40deg) scale(1.05); }
-    66%  { transform: translate(-10vw, 4vh) rotate(-30deg) scale(0.93); }
-    77%  { transform: translate(3vw, 9vh) rotate(15deg) scale(1.02); }
-    88%  { transform: translate(-6vw, -3vh) rotate(-25deg) scale(0.99); }
-    100% { transform: translate(0, 0) rotate(0deg) scale(1); }
+    0%   { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
+    11%  { transform: translate3d(75px, -50px, 0) rotate(25deg) scale(1.04); }
+    22%  { transform: translate3d(-100px, -70px, 0) rotate(-35deg) scale(0.94); }
+    33%  { transform: translate3d(125px, 60px, 0) rotate(45deg) scale(1.06); }
+    44%  { transform: translate3d(-65px, 110px, 0) rotate(-20deg) scale(0.97); }
+    55%  { transform: translate3d(85px, -100px, 0) rotate(40deg) scale(1.05); }
+    66%  { transform: translate3d(-120px, 45px, 0) rotate(-30deg) scale(0.93); }
+    77%  { transform: translate3d(45px, 90px, 0) rotate(15deg) scale(1.02); }
+    88%  { transform: translate3d(-75px, -35px, 0) rotate(-25deg) scale(0.99); }
+    100% { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
   }
   @keyframes float6 {
-    0%   { transform: translate(0, 0) rotate(0deg) scale(1); }
-    18%  { transform: translate(-9vw, 4vh) rotate(-45deg) scale(1.05); }
-    36%  { transform: translate(5vw, -10vh) rotate(35deg) scale(0.94); }
-    54%  { transform: translate(-3vw, 11vh) rotate(-30deg) scale(1.06); }
-    72%  { transform: translate(8vw, 3vh) rotate(50deg) scale(0.95); }
-    90%  { transform: translate(-6vw, -8vh) rotate(-15deg) scale(1.02); }
-    100% { transform: translate(0, 0) rotate(0deg) scale(1); }
+    0%   { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
+    18%  { transform: translate3d(-115px, 50px, 0) rotate(-45deg) scale(1.05); }
+    36%  { transform: translate3d(70px, -100px, 0) rotate(35deg) scale(0.94); }
+    54%  { transform: translate3d(-40px, 115px, 0) rotate(-30deg) scale(1.06); }
+    72%  { transform: translate3d(95px, 35px, 0) rotate(50deg) scale(0.95); }
+    90%  { transform: translate3d(-80px, -85px, 0) rotate(-15deg) scale(1.02); }
+    100% { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
   }
 
   @keyframes pop-in {


### PR DESCRIPTION
## Summary

兩個針對 iOS Safari 的修法：

- **彩球完全看不到 → 改用 CSS Grid 排版**：`.lottery-arena` 原本用 `flex: 1 1 auto; min-height: 0`，但子元素全是 `position: absolute` 不貢獻 flow 高度，iOS Safari 會把 arena 算成 0 高度，所有 `top: X%` 塌成 0、再被 `overflow: hidden` 切掉，loading 畫面就一片空白直接跳到結果頁。改用 `grid-template-rows: auto 1fr`（grid 1fr 在算法上一定是 definite size），加 `min-height: 240px` 當 fallback。
- **彩球出現但不亂飛 → 動畫改 translate3d + px**：iOS 低耗電模式（Low Power Mode）會大幅限流 CPU-driven 動畫，把彩球凍住。`translate3d` 強制走 GPU compositor layer，LPM 限流幅度小很多，至少肉眼還會動；同時把 `vw`/`vh` 改回 `px`，因為 iOS Safari 在 `@keyframes` 裡評估 viewport units 不太穩定，px 通用又可靠。

## Test plan

- [ ] iPhone Safari 一般模式：彩球出現且亂飛 5 秒後切到結果頁
- [ ] iPhone Safari 低耗電模式（黃色閃電電池）：彩球至少看得出有在動（不會完全靜止）
- [ ] iPad Safari：同上
- [ ] Chrome / Firefox 桌機：行為不變、動畫流暢
- [ ] 抽 1 / 5 / 20 人 各跑一次，確認彩球密度與得獎卡片排版都正常

https://claude.ai/code/session_012K3Ypa9Lp5XWjerDpRynSk

---
_Generated by [Claude Code](https://claude.ai/code/session_012K3Ypa9Lp5XWjerDpRynSk)_