### PR TITLE
Fix lottery balls never animating (Vue scoped CSS keyframe rename)

### DIFF
--- a/src/components/LoadingPage.vue
+++ b/src/components/LoadingPage.vue
@@ -343,11 +343,66 @@
     white-space: nowrap;
   }
 
-  /* translate3d forces a GPU compositor layer so the animation keeps
-     running smoothly under iOS Low Power Mode and avoids jank from
-     repaint. Magnitudes are px (not vw/vh) because iOS Safari has
-     historically evaluated viewport units inside @keyframes
-     inconsistently. */
+  @keyframes pop-in {
+    0% {
+      opacity: 0;
+      transform: scale(0.2) rotate(-20deg);
+    }
+    60% {
+      opacity: 1;
+      transform: scale(1.15) rotate(6deg);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1) rotate(0);
+    }
+  }
+
+  @keyframes glow {
+    0% {
+      box-shadow: 0 0 30px rgba(255, 215, 0, 0.6),
+        0 12px 30px rgba(205, 0, 0, 0.35),
+        inset 0 -10px 20px rgba(0, 0, 0, 0.18),
+        inset 0 10px 20px rgba(255, 255, 255, 0.35);
+    }
+    100% {
+      box-shadow: 0 0 60px rgba(255, 215, 0, 1),
+        0 12px 40px rgba(205, 0, 0, 0.5),
+        inset 0 -10px 20px rgba(0, 0, 0, 0.18),
+        inset 0 10px 20px rgba(255, 255, 255, 0.35);
+    }
+  }
+
+  @media (max-width: 768px) {
+    .deco {
+      max-height: 18vh;
+      opacity: 0.6;
+    }
+    .ball-name {
+      padding: 1px 8px;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .deco {
+      display: none;
+    }
+  }
+</style>
+
+<!--
+  Global (non-scoped) keyframes. We reference these via inline
+  `:style="{ animationName: 'floatN' }"` from the template; if the
+  keyframes lived in <style scoped>, Vue would rewrite them to
+  `floatN-<hash>` and the inline `animation-name` (which Vue does NOT
+  rewrite at runtime) would no longer match — the result is balls that
+  render but never animate.
+
+  translate3d forces a GPU compositor layer (smooth on iOS Safari and
+  more resilient under Low Power Mode). Magnitudes are px because iOS
+  Safari has been inconsistent about evaluating vw/vh inside @keyframes.
+-->
+<style>
   @keyframes float1 {
     0%   { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
     14%  { transform: translate3d(95px, -75px, 0) rotate(35deg) scale(1.04); }
@@ -406,51 +461,5 @@
     72%  { transform: translate3d(95px, 35px, 0) rotate(50deg) scale(0.95); }
     90%  { transform: translate3d(-80px, -85px, 0) rotate(-15deg) scale(1.02); }
     100% { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
-  }
-
-  @keyframes pop-in {
-    0% {
-      opacity: 0;
-      transform: scale(0.2) rotate(-20deg);
-    }
-    60% {
-      opacity: 1;
-      transform: scale(1.15) rotate(6deg);
-    }
-    100% {
-      opacity: 1;
-      transform: scale(1) rotate(0);
-    }
-  }
-
-  @keyframes glow {
-    0% {
-      box-shadow: 0 0 30px rgba(255, 215, 0, 0.6),
-        0 12px 30px rgba(205, 0, 0, 0.35),
-        inset 0 -10px 20px rgba(0, 0, 0, 0.18),
-        inset 0 10px 20px rgba(255, 255, 255, 0.35);
-    }
-    100% {
-      box-shadow: 0 0 60px rgba(255, 215, 0, 1),
-        0 12px 40px rgba(205, 0, 0, 0.5),
-        inset 0 -10px 20px rgba(0, 0, 0, 0.18),
-        inset 0 10px 20px rgba(255, 255, 255, 0.35);
-    }
-  }
-
-  @media (max-width: 768px) {
-    .deco {
-      max-height: 18vh;
-      opacity: 0.6;
-    }
-    .ball-name {
-      padding: 1px 8px;
-    }
-  }
-
-  @media (max-width: 480px) {
-    .deco {
-      display: none;
-    }
   }
 </style>


### PR DESCRIPTION
## Summary

**真正的 root cause**：Vue `<style scoped>` 為了做樣式隔離，會把 `@keyframes float1` 重新命名成 `@keyframes float1-<hash>`，但我用 inline `:style="{ animationName: 'float1' }"` 在 template 設的引用是原始名稱「`float1`」（Vue 不會 rewrite runtime 的 inline style）—— 名稱對不上，`animation-name` 查無此 keyframe，於是每顆球都停在初始位置不動。

PR #6 / PR #7 推測的低耗電模式、`vw`/`vh` 評估、translate3d 都是 red herrings——這個 bug 在所有瀏覽器都會發生（不只 iOS Safari）。我跑 `dist/assets/*.css` 直接 grep 才看到 `@keyframes float1-1b7f485b`，名稱被改掉的鐵證。

**修法**：把 6 個 `float` keyframes 拆到第二個**非 scoped** `<style>` block（Vue SFC 支援多個 style 區塊）。輸出後 keyframe 名稱保持原樣，inline `animation-name: float1` 就能對到。`pop-in` / `glow` 因為是用 class 引用、Vue 會在編譯期 rewrite 引用，所以仍可放在 scoped block 內部。

驗證：build 後 `grep '@keyframes' dist/assets/*.css` 顯示 `@keyframes float1` … `@keyframes float6` 都是原始名稱。

## Test plan

- [ ] iPhone Safari：彩球出現後在 arena 內亂飛 ~3.8 秒
- [ ] 桌面 Chrome / Firefox：行為一致
- [ ] 100 人名單也能正常飛（球縮到 44px，不破版）
- [ ] 5 秒後得獎人從中央 pop-in，落選球淡出（這兩個動畫之前其實也壞了，這 PR 同時修好）

https://claude.ai/code/session_012K3Ypa9Lp5XWjerDpRynSk

---
_Generated by [Claude Code](https://claude.ai/code/session_012K3Ypa9Lp5XWjerDpRynSk)_