### PR TITLE
Stagger winner reveals with drop-and-bounce animation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -68,9 +68,10 @@
     }
     winners.value = drawing(nameListArr.value, +headcount.value);
     pageState.value = 'loading';
-    setTimeout(() => {
-      pageState.value = 'result';
-    }, 5000);
+  };
+
+  const handleLoadingDone = () => {
+    pageState.value = 'result';
   };
 
   const handleNext = () => {
@@ -111,6 +112,7 @@
       v-else-if="pageState == 'loading'"
       :nameList="nameListArr"
       :winners="winners"
+      @done="handleLoadingDone"
     />
     <RecordPage v-else-if="pageState == 'record'" @back="handleBack" />
     <ResultPage :winners="winners" :awards="awards" @next="handleNext" v-else />

--- a/src/components/LoadingPage.vue
+++ b/src/components/LoadingPage.vue
@@ -41,7 +41,7 @@
             :key="winner"
             class="winner-card"
             :style="{
-              animationDelay: i * 0.12 + 's',
+              animationDelay: i * 0.6 + 's',
               '--card-w': winnerCardWidth,
             }"
           >
@@ -81,6 +81,7 @@
     winners: string[];
   }
   const props = defineProps<IProps>();
+  const emit = defineEmits<{ (e: 'done'): void }>();
 
   const phase = ref<'flying' | 'reveal'>('flying');
 
@@ -134,14 +135,35 @@
     }),
   );
 
-  let revealTimer: number | undefined;
+  let timers: number[] = [];
   onMounted(() => {
-    revealTimer = window.setTimeout(() => {
-      phase.value = 'reveal';
-    }, 3800);
+    // Stagger each winner reveal by STAGGER_MS so the audience sees them
+    // dropped one at a time. Total run time scales with winner count;
+    // App.vue waits for the `done` event instead of a fixed 5s timer.
+    const FLYING_MS = 3000;
+    const STAGGER_MS = 600;
+    const POP_MS = 800;
+    const TAIL_MS = 1100;
+
+    timers.push(
+      window.setTimeout(() => {
+        phase.value = 'reveal';
+      }, FLYING_MS),
+    );
+
+    const totalMs =
+      FLYING_MS +
+      Math.max(0, props.winners.length - 1) * STAGGER_MS +
+      POP_MS +
+      TAIL_MS;
+    timers.push(
+      window.setTimeout(() => {
+        emit('done');
+      }, totalMs),
+    );
   });
   onUnmounted(() => {
-    if (revealTimer) clearTimeout(revealTimer);
+    timers.forEach((t) => clearTimeout(t));
   });
 </script>
 
@@ -300,7 +322,7 @@
     align-items: center;
     gap: clamp(6px, 1.4vh, 14px);
     width: var(--card-w, 200px);
-    animation: pop-in 0.7s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+    animation: drop-in 0.8s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
   }
 
   .winner-avatar {
@@ -343,18 +365,24 @@
     white-space: nowrap;
   }
 
-  @keyframes pop-in {
+  @keyframes drop-in {
     0% {
       opacity: 0;
-      transform: scale(0.2) rotate(-20deg);
+      transform: translate3d(0, -65vh, 0) scale(0.55) rotate(-12deg);
     }
-    60% {
+    55% {
       opacity: 1;
-      transform: scale(1.15) rotate(6deg);
+      transform: translate3d(0, 18px, 0) scale(1.12) rotate(6deg);
+    }
+    72% {
+      transform: translate3d(0, -10px, 0) scale(0.97) rotate(-3deg);
+    }
+    86% {
+      transform: translate3d(0, 4px, 0) scale(1.02) rotate(1deg);
     }
     100% {
       opacity: 1;
-      transform: scale(1) rotate(0);
+      transform: translate3d(0, 0, 0) scale(1) rotate(0);
     }
   }
 


### PR DESCRIPTION
## Summary

把得獎人改成一個一個「掉下來」，並讓 loading 階段時間隨人數延長。

- **drop-in 動畫**：每張得獎卡從 `-65vh` 掉下、過頭 18px、回彈 -10px、再 4px、停在定位（0.8s `cubic-bezier(0.34, 1.56, 0.64, 1)`），有明確的「球從機器掉出來、落地彈一下」感。
- **600ms stagger**：第 i 位得獎人 `animation-delay: i * 0.6s`，audience 看得到每張卡片個別出場。
- **動態總時長**：`LoadingPage` 現在用 `FLYING_MS(3000) + (N-1) * STAGGER_MS(600) + POP_MS(800) + TAIL_MS(1100)` 算總時間，跑完才 `emit('done')`。`App.vue` 改成 `@done="pageState = 'result'"`，不再寫死 5s。
  - 1 人：4.9s
  - 5 人：7.3s
  - 10 人：10.3s
  - 20 人：16.3s

## Test plan

- [ ] 抽 1 人：~5s 後轉場，drop 動畫看得到從上方掉下
- [ ] 抽 5 人：5 張卡片一張一張落下，最後一張落定後約 1s 才轉場
- [ ] 抽 20 人：最後一張落下時前面的卡片已穩定不抖
- [ ] iOS Safari：動畫流暢、轉場時機正確（不會提早切走）
- [ ] 抽獎中按瀏覽器返回：timer 正確 cleanup、不會在背景切到 result page

https://claude.ai/code/session_012K3Ypa9Lp5XWjerDpRynSk

---
_Generated by [Claude Code](https://claude.ai/code/session_012K3Ypa9Lp5XWjerDpRynSk)_