### PR TITLE
chore: 暫時停用 Slack avatar 自動同步排程

### DIFF
--- a/.github/workflows/sync-slack-avatars.yml
+++ b/.github/workflows/sync-slack-avatars.yml
@@ -2,9 +2,6 @@ name: Sync Slack avatars
 
 on:
   workflow_dispatch:
-  schedule:
-    # 每週一 09:00 (Asia/Taipei) = 01:00 UTC
-    - cron: '0 1 * * 1'
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- 移除 `sync-slack-avatars.yml` 的 `schedule` cron 觸發器，暫停每週自動抓取員工頭像
- 保留 `workflow_dispatch`，需要時仍可手動執行
- 員工名單 JSON 的 git 歷程記錄已另外透過 `git filter-repo` 從 master 完全清除

## Test plan

- [ ] 合併後確認 GitHub Actions 頁面中 `Sync Slack avatars` 不再出現排程執行
- [ ] 手動觸發 workflow 確認功能仍正常

https://claude.ai/code/session_01GYLudGFb11VrJ2qPGWWaSR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYLudGFb11VrJ2qPGWWaSR)_