### PR TITLE
feat: 新增頭像設定頁面（上傳 JSON / URL 載入）& 停用自動排程

### DIFF
--- a/.github/workflows/sync-slack-avatars.yml
+++ b/.github/workflows/sync-slack-avatars.yml
@@ -2,9 +2,6 @@ name: Sync Slack avatars
 
 on:
   workflow_dispatch:
-  schedule:
-    # 每週一 09:00 (Asia/Taipei) = 01:00 UTC
-    - cron: '0 1 * * 1'
 
 permissions:
   contents: write

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,6 +4,7 @@
   import LoadingPage from './components/LoadingPage.vue';
   import ResultPage from './components/ResultPage.vue';
   import RecordPage from './components/RecordPage.vue';
+  import SettingsPage from './components/SettingsPage.vue';
   import { xor } from 'lodash-es';
   import Swal from 'sweetalert2';
   import { drawing } from './libs/libs';
@@ -13,7 +14,7 @@
   loadAvatarMap();
 
   const loadingPage = ref();
-  const pageState = ref<'init' | 'loading' | 'result' | 'record'>('init');
+  const pageState = ref<'init' | 'loading' | 'result' | 'record' | 'settings'>('init');
   const awards = ref('');
   const headcount = ref<number | ''>('');
   const nameList = ref<string>('');
@@ -92,6 +93,10 @@
     pageState.value = 'record';
   };
 
+  const handleGoSettings = () => {
+    pageState.value = 'settings';
+  };
+
   const handleBack = () => {
     pageState.value = 'init';
   };
@@ -106,6 +111,7 @@
       v-model:nameList="nameList"
       @start="handleStart"
       @goRecord="handleGoRecord"
+      @goSettings="handleGoSettings"
     />
     <LoadingPage
       ref="loadingPage"
@@ -115,6 +121,7 @@
       @done="handleLoadingDone"
     />
     <RecordPage v-else-if="pageState == 'record'" @back="handleBack" />
+    <SettingsPage v-else-if="pageState == 'settings'" @back="handleBack" />
     <ResultPage :winners="winners" :awards="awards" @next="handleNext" v-else />
   </div>
 </template>

--- a/src/components/InitPage.vue
+++ b/src/components/InitPage.vue
@@ -4,6 +4,7 @@
     <img src="../assets/left.png" class="deco deco-left" />
     <img src="../assets/right.png" class="deco deco-right" />
 
+    <button class="settings-btn" @click="$emit('goSettings')">頭像設定</button>
     <button class="record-btn" @click="$emit('goRecord')">抽獎紀錄</button>
 
     <div class="content">
@@ -61,6 +62,7 @@
     'update:nameList',
     'start',
     'goRecord',
+    'goSettings',
   ]);
   const awards = computed({
     get() {
@@ -126,6 +128,19 @@
     bottom: 4vh;
   }
 
+  .settings-btn {
+    position: absolute;
+    z-index: 40;
+    left: clamp(12px, 3vw, 40px);
+    top: clamp(12px, 3vh, 40px);
+    color: #cd0000;
+    font-size: clamp(14px, 2vh, 20px);
+    font-weight: 700;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+  }
+
   .record-btn {
     position: absolute;
     z-index: 40;
@@ -136,6 +151,7 @@
     font-weight: 700;
     background: transparent;
     border: 0;
+    cursor: pointer;
   }
 
   .content {

--- a/src/components/SettingsPage.vue
+++ b/src/components/SettingsPage.vue
@@ -1,0 +1,356 @@
+<template>
+  <div class="page">
+    <img src="../assets/bg-circle.png" class="bg-circle" />
+    <img src="../assets/left.png" class="deco deco-left" />
+    <img src="../assets/right.png" class="deco deco-right" />
+
+    <button class="back-btn" @click="$emit('back')">← 返回</button>
+
+    <div class="content">
+      <h2 class="title">頭像設定</h2>
+
+      <div class="card">
+        <div class="status-row">
+          <span class="badge" :class="source === 'custom' ? 'badge-custom' : 'badge-default'">
+            {{ source === 'custom' ? '自訂清單' : '預設清單' }}
+          </span>
+          <span class="count-text">{{ entryCount }} 筆</span>
+          <button v-if="source === 'custom'" class="text-btn" @click="handleClear">
+            清除自訂
+          </button>
+        </div>
+
+        <section class="section">
+          <div class="section-title">上傳 JSON 檔案</div>
+          <label class="upload-zone">
+            <span class="upload-arrow">↑</span>
+            <span class="upload-label">{{ filename || '點擊選擇 .json 檔案' }}</span>
+            <input type="file" accept=".json,application/json" @change="handleFile" hidden />
+          </label>
+        </section>
+
+        <div class="divider">或</div>
+
+        <section class="section">
+          <div class="section-title">從 URL 載入</div>
+          <div class="url-row">
+            <input
+              class="url-input"
+              v-model="urlInput"
+              placeholder="https://example.com/avatars.json"
+              @keydown.enter="handleFetch"
+            />
+            <button
+              class="fetch-btn"
+              @click="handleFetch"
+              :disabled="loading || !urlInput.trim()"
+            >
+              {{ loading ? '載入中…' : '載入' }}
+            </button>
+          </div>
+          <div class="hint">目標伺服器需允許跨域（CORS），若失敗請改用上傳檔案方式</div>
+        </section>
+
+        <div v-if="message" class="message" :class="messageType">{{ message }}</div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { ref, computed } from 'vue';
+  import {
+    applyCustomAvatarMap,
+    clearCustomAvatarMap,
+    getAvatarSource,
+    avatarEntryCount,
+  } from '../libs/avatar';
+
+  defineEmits(['back']);
+
+  const source = ref(getAvatarSource());
+  const filename = ref('');
+  const urlInput = ref('');
+  const loading = ref(false);
+  const message = ref('');
+  const messageType = ref<'success' | 'error'>('success');
+
+  const entryCount = computed(() => avatarEntryCount.value);
+
+  const showMsg = (text: string, type: 'success' | 'error') => {
+    message.value = text;
+    messageType.value = type;
+  };
+
+  const validate = (data: unknown): data is Record<string, string> =>
+    !!data && typeof data === 'object' && !Array.isArray(data);
+
+  const handleFile = (e: Event) => {
+    const file = (e.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+    filename.value = file.name;
+    message.value = '';
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      try {
+        const data = JSON.parse(ev.target?.result as string);
+        if (!validate(data)) throw new Error();
+        applyCustomAvatarMap(data as Record<string, string>);
+        source.value = 'custom';
+        showMsg(`成功載入 ${Object.keys(data).length} 筆頭像資料`, 'success');
+      } catch {
+        showMsg('JSON 格式錯誤，請確認格式為 { "名字": "圖片URL" }', 'error');
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const handleFetch = async () => {
+    const url = urlInput.value.trim();
+    if (!url || loading.value) return;
+    loading.value = true;
+    message.value = '';
+    try {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      if (!validate(data)) throw new Error('格式錯誤');
+      applyCustomAvatarMap(data as Record<string, string>);
+      source.value = 'custom';
+      showMsg(`成功載入 ${Object.keys(data).length} 筆頭像資料`, 'success');
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : '未知錯誤';
+      showMsg(`載入失敗：${msg}`, 'error');
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const handleClear = () => {
+    clearCustomAvatarMap();
+    source.value = 'default';
+    filename.value = '';
+    urlInput.value = '';
+    message.value = '';
+  };
+</script>
+
+<style scoped>
+  .page {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    height: 100svh;
+    overflow: hidden;
+    color: #222;
+  }
+
+  .bg-circle {
+    position: absolute;
+    width: 100%;
+    bottom: -10%;
+    left: 0;
+    z-index: 0;
+    pointer-events: none;
+  }
+
+  .deco {
+    position: absolute;
+    z-index: 0;
+    pointer-events: none;
+    max-height: 26vh;
+    object-fit: contain;
+  }
+  .deco-left { left: 2vw; bottom: 4vh; }
+  .deco-right { right: 2vw; bottom: 4vh; }
+
+  .back-btn {
+    position: absolute;
+    z-index: 40;
+    left: clamp(12px, 3vw, 40px);
+    top: clamp(12px, 3vh, 40px);
+    color: #cd0000;
+    font-size: clamp(14px, 2vh, 18px);
+    font-weight: 700;
+    background: transparent;
+    border: 0;
+    cursor: pointer;
+  }
+
+  .content {
+    position: relative;
+    z-index: 10;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: clamp(8px, 2vh, 24px) clamp(12px, 3vw, 32px);
+    box-sizing: border-box;
+    gap: clamp(12px, 2vh, 20px);
+  }
+
+  .title {
+    color: #cd0000;
+    font-size: clamp(22px, 4vh, 36px);
+    font-weight: 800;
+    margin: 0;
+    letter-spacing: 0.08em;
+  }
+
+  .card {
+    width: min(580px, 94vw);
+    background: #c10d23ef;
+    border-radius: clamp(10px, 1.6vh, 16px);
+    padding: clamp(16px, 2.6vh, 32px) clamp(18px, 3vw, 40px);
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.22);
+    display: flex;
+    flex-direction: column;
+    gap: clamp(12px, 2vh, 18px);
+    box-sizing: border-box;
+  }
+
+  .status-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .badge {
+    border-radius: 999px;
+    padding: 4px 14px;
+    font-size: clamp(12px, 1.6vh, 14px);
+    font-weight: 700;
+  }
+  .badge-custom { background: #fff; color: #cd0000; }
+  .badge-default { background: rgba(255, 255, 255, 0.25); color: #fff; }
+
+  .count-text {
+    flex: 1;
+    color: rgba(255, 255, 255, 0.8);
+    font-size: clamp(12px, 1.6vh, 14px);
+  }
+
+  .text-btn {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    border-radius: 999px;
+    padding: 4px 14px;
+    font-size: clamp(11px, 1.5vh, 13px);
+    font-weight: 600;
+    color: #fff;
+    cursor: pointer;
+    transition: background 0.15s;
+  }
+  .text-btn:hover { background: rgba(255, 255, 255, 0.15); }
+
+  .section { display: flex; flex-direction: column; gap: 8px; }
+
+  .section-title {
+    color: rgba(255, 255, 255, 0.9);
+    font-size: clamp(13px, 1.8vh, 15px);
+    font-weight: 700;
+  }
+
+  .upload-zone {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    height: clamp(44px, 6vh, 54px);
+    background: #ffefef;
+    border-radius: 999px;
+    padding: 0 clamp(14px, 2vw, 24px);
+    cursor: pointer;
+    font-size: clamp(13px, 1.8vh, 15px);
+    color: #4e4c4c;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+    transition: background 0.15s;
+    overflow: hidden;
+    box-sizing: border-box;
+  }
+  .upload-zone:hover { background: #ffe0e0; }
+
+  .upload-arrow {
+    font-size: 1.3em;
+    font-weight: 900;
+    color: #cd0000;
+    flex-shrink: 0;
+  }
+
+  .upload-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .divider {
+    text-align: center;
+    color: rgba(255, 255, 255, 0.55);
+    font-size: clamp(12px, 1.6vh, 14px);
+    font-weight: 700;
+    letter-spacing: 0.2em;
+  }
+
+  .url-row {
+    display: flex;
+    gap: 8px;
+  }
+
+  .url-input {
+    flex: 1;
+    min-width: 0;
+    height: clamp(40px, 5.5vh, 50px);
+    background: #ffefef;
+    border: 0;
+    border-radius: 999px;
+    padding: 0 clamp(14px, 2vw, 20px);
+    font-size: clamp(13px, 1.8vh, 15px);
+    color: #000;
+    outline: 0;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.12);
+    box-sizing: border-box;
+  }
+  .url-input:focus { outline: 2px solid #fff; outline-offset: 2px; }
+
+  .fetch-btn {
+    height: clamp(40px, 5.5vh, 50px);
+    background: #4e4c4c;
+    color: #fff;
+    border: 0;
+    border-radius: 999px;
+    padding: 0 clamp(14px, 2vw, 22px);
+    font-size: clamp(13px, 1.8vh, 15px);
+    font-weight: 700;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.15s;
+    flex-shrink: 0;
+  }
+  .fetch-btn:hover:not(:disabled) { background: #222; }
+  .fetch-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .hint {
+    color: rgba(255, 255, 255, 0.55);
+    font-size: clamp(11px, 1.4vh, 12px);
+    line-height: 1.5;
+    padding: 0 4px;
+  }
+
+  .message {
+    border-radius: clamp(8px, 1.4vh, 12px);
+    padding: clamp(8px, 1.4vh, 12px) clamp(12px, 2vw, 18px);
+    font-size: clamp(13px, 1.8vh, 15px);
+    font-weight: 600;
+  }
+  .message.success { background: rgba(255, 255, 255, 0.95); color: #2e7d32; }
+  .message.error { background: rgba(255, 255, 255, 0.95); color: #c62828; }
+
+  @media (max-width: 768px) {
+    .deco { max-height: 14vh; opacity: 0.5; }
+  }
+  @media (max-width: 480px) {
+    .deco { display: none; }
+  }
+</style>

--- a/src/libs/avatar.ts
+++ b/src/libs/avatar.ts
@@ -2,12 +2,15 @@
 // shaped like `{ "王小明": "https://...jpg", ... }` and matching names will
 // render with the real photo. Names not in the map fall back to a
 // deterministic gradient + initials avatar.
+//
+// A custom map uploaded via the settings page takes priority and is stored
+// in localStorage under STORAGE_KEY.
 
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
+
+const STORAGE_KEY = 'avatarMapCustom';
 
 const avatarMap = ref<Record<string, string>>({});
-// Secondary index: Chinese/CJK prefix → url, for fuzzy lookup when the
-// lottery name list uses shorter names than the full Slack display name.
 const shortIndex: Record<string, string> = {};
 
 let mapPromise: Promise<void> | null = null;
@@ -18,20 +21,34 @@ const cjkPrefix = (s: string): string => {
   return m ? m[0] : '';
 };
 
+const applyData = (data: Record<string, string>) => {
+  for (const key of Object.keys(shortIndex)) delete shortIndex[key];
+  avatarMap.value = data;
+  for (const [k, v] of Object.entries(data)) {
+    const prefix = cjkPrefix(k);
+    if (prefix && !(prefix in shortIndex)) shortIndex[prefix] = v;
+  }
+};
+
 export const loadAvatarMap = (): Promise<void> => {
   if (mapPromise) return mapPromise;
   mapPromise = (async () => {
     try {
+      // Custom map from settings page takes priority over the public file.
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          applyData(parsed as Record<string, string>);
+          return;
+        }
+      }
       const url = `${import.meta.env.BASE_URL}slack-avatars.json`;
       const res = await fetch(url, { cache: 'no-cache' });
       if (res.ok) {
         const data = await res.json();
         if (data && typeof data === 'object') {
-          avatarMap.value = data as Record<string, string>;
-          for (const [k, v] of Object.entries(avatarMap.value)) {
-            const prefix = cjkPrefix(k);
-            if (prefix && !(prefix in shortIndex)) shortIndex[prefix] = v;
-          }
+          applyData(data as Record<string, string>);
         }
       }
     } catch {
@@ -40,6 +57,23 @@ export const loadAvatarMap = (): Promise<void> => {
   })();
   return mapPromise;
 };
+
+export const applyCustomAvatarMap = (data: Record<string, string>): void => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  applyData(data);
+};
+
+export const clearCustomAvatarMap = (): void => {
+  localStorage.removeItem(STORAGE_KEY);
+  applyData({});
+  mapPromise = null;
+  loadAvatarMap();
+};
+
+export const getAvatarSource = (): 'custom' | 'default' =>
+  localStorage.getItem(STORAGE_KEY) !== null ? 'custom' : 'default';
+
+export const avatarEntryCount = computed(() => Object.keys(avatarMap.value).length);
 
 export const getAvatarUrl = (name: string): string | undefined => {
   const t = name.trim();


### PR DESCRIPTION
## Summary

- 首頁左上角新增「頭像設定」按鈕，進入設定頁面
- 設定頁面支援兩種方式匯入頭像對照 JSON：
  - **上傳檔案**：點擊選擇本機 `.json` 檔案
  - **輸入 URL**：貼上可存取的 JSON URL，按「載入」自動 fetch
- 自訂資料存入 `localStorage`，下次開啟仍保留，且優先於 `public/slack-avatars.json`
- 可隨時「清除自訂」恢復預設；頁面顯示目前來源（自訂 / 預設）與筆數
- 停用 `sync-slack-avatars` 自動排程（保留手動觸發）

## JSON 格式

```json
{
  "王小明": "https://example.com/avatar.jpg",
  "Johnny Yu": "https://example.com/johnny.png"
}
```

## Test plan

- [ ] 首頁左上角出現「頭像設定」按鈕
- [ ] 進入設定頁，上傳有效 JSON 後顯示「成功載入 N 筆」
- [ ] 上傳後返回首頁開始抽獎，loading 頁面顯示正確頭像
- [ ] 輸入無效 URL 或格式錯誤 JSON 時顯示錯誤訊息
- [ ] 點擊「清除自訂」後恢復預設清單
- [ ] 重新整理頁面後自訂清單仍保留
- [ ] GitHub Actions 頁面確認排程不再出現

https://claude.ai/code/session_01GYLudGFb11VrJ2qPGWWaSR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYLudGFb11VrJ2qPGWWaSR)_