### PR TITLE
Wrap long winner names instead of truncating with ellipsis

### DIFF
--- a/src/components/LoadingPage.vue
+++ b/src/components/LoadingPage.vue
@@ -360,9 +360,10 @@
     letter-spacing: 0.06em;
     box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
     max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
+    word-break: break-word;
+    text-align: center;
+    line-height: 1.25;
   }
 
   @keyframes drop-in {

--- a/src/components/ResultPage.vue
+++ b/src/components/ResultPage.vue
@@ -270,9 +270,10 @@
     box-shadow: inset -2px -3px 0 rgba(0, 0, 0, 0.25),
       0 6px 14px rgba(205, 0, 0, 0.3);
     max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
+    word-break: break-word;
+    text-align: center;
+    line-height: 1.25;
   }
 
   .size-xl .winner-name {


### PR DESCRIPTION
## Summary

從 PR #15 的 commit `c540929` cherry-pick 到最新 master（PR #15 的舊 branch 已落後 master 38 commit、有衝突，這個 fresh branch 直接從最新 master 開出來、無衝突）。

得獎名單兩處 `.winner-name`（loading 掉落卡片、result page 卡片）原本用 `white-space: nowrap` + `text-overflow: ellipsis`，導致 4-5 字以上的中文姓名或長英文名會被截成 `Christop…`。改成允許換行：

- `white-space: normal`
- `word-break: break-word`
- `text-align: center`
- `line-height: 1.25`

長名字會自動斷成兩行、置中對齊，圓角徽章因為 `border-radius: 999px` 會自然撐高。

飛舞中的小球標籤 `.ball-name` 保持 ellipsis — 80+ 顆球擠在一起時，標籤換行會互相重疊變得很亂。

## Test plan

- [ ] 測試名字：「王小明」「Christopher Liu」「陳大文超長名字測試」「Yvonne Shih」
- [ ] 中獎 1 / 3 / 8 人都能完整顯示，不被截斷
- [ ] 卡片高度自動撐高、不會擠壓頭像
- [ ] 飛舞球的小標籤仍維持單行 ellipsis

https://claude.ai/code/session_012K3Ypa9Lp5XWjerDpRynSk

---
_Generated by [Claude Code](https://claude.ai/code/session_012K3Ypa9Lp5XWjerDpRynSk)_