### PR TITLE
Redesign result page as horizontal avatar+name cards (fixed grid)

### DIFF
--- a/src/components/ResultPage.vue
+++ b/src/components/ResultPage.vue
@@ -14,12 +14,12 @@
         <div class="winners-count">
           得獎名單：共 {{ winners.length }} 位
         </div>
-        <div :class="['winners-grid', sizeClass]">
+        <div :class="['winners-grid', tierClass]">
           <div
             v-for="(winner, i) in winners"
             :key="winner"
             class="winner-card"
-            :style="{ animationDelay: i * 0.08 + 's' }"
+            :style="{ animationDelay: i * 0.05 + 's' }"
           >
             <div
               class="winner-avatar"
@@ -65,13 +65,18 @@
 
   defineEmits(['next']);
 
-  const sizeClass = computed(() => {
+  // Tier picks the grid column count; rows are auto-derived (1fr)
+  // so every card occupies the same height regardless of winner count.
+  // Tier-1 is the lone "grand prize" case — stacked column layout,
+  // everything else is a horizontal avatar+name strip.
+  const tierClass = computed(() => {
     const n = props.winners.length;
-    if (n <= 1) return 'size-xl';
-    if (n <= 3) return 'size-lg';
-    if (n <= 6) return 'size-md';
-    if (n <= 12) return 'size-sm';
-    return 'size-xs';
+    if (n <= 1) return 'tier-1';
+    if (n <= 4) return 'tier-2';
+    if (n <= 9) return 'tier-3';
+    if (n <= 16) return 'tier-4';
+    if (n <= 25) return 'tier-5';
+    return 'tier-6';
   });
 
   const onImgError = (e: Event) => {
@@ -96,23 +101,24 @@
     left: 0;
     z-index: 0;
     pointer-events: none;
-    opacity: 0.6;
+    opacity: 0.5;
   }
 
   .deco {
     position: absolute;
     z-index: 0;
     pointer-events: none;
-    max-height: 28vh;
+    max-height: 18vh;
     object-fit: contain;
+    opacity: 0.6;
   }
   .deco-left {
-    left: 2vw;
-    bottom: 4vh;
+    left: 1vw;
+    bottom: 2vh;
   }
   .deco-right {
-    right: 2vw;
-    bottom: 4vh;
+    right: 1vw;
+    bottom: 2vh;
   }
 
   .content {
@@ -123,36 +129,36 @@
     align-items: center;
     width: 100%;
     height: 100%;
-    padding: clamp(12px, 3vh, 28px) clamp(12px, 3vw, 32px);
+    padding: clamp(10px, 2.4vh, 24px) clamp(12px, 3vw, 32px);
     box-sizing: border-box;
-    gap: clamp(10px, 2vh, 22px);
+    gap: clamp(8px, 1.6vh, 18px);
   }
 
   .result-header {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: clamp(6px, 1.2vh, 16px);
+    gap: clamp(4px, 0.8vh, 12px);
     flex-shrink: 0;
   }
 
   .logo {
-    width: clamp(48px, 8vh, 86px);
+    width: clamp(40px, 6.5vh, 72px);
     height: auto;
   }
 
   .awards-badge {
     background: linear-gradient(135deg, #ffd7d7 0%, #ffe8e8 100%);
     color: #cd0000;
-    padding: clamp(8px, 1.5vh, 16px) clamp(20px, 4vw, 60px);
+    padding: clamp(6px, 1.2vh, 14px) clamp(18px, 4vw, 56px);
     border-radius: 999px;
-    font-size: clamp(22px, 4.2vh, 48px);
+    font-size: clamp(20px, 3.6vh, 42px);
     font-weight: 800;
     letter-spacing: 0.08em;
     margin: 0;
     box-shadow: inset -2px -4px 0 rgba(206, 3, 33, 0.4),
-      0 12px 30px rgba(205, 0, 0, 0.18);
-    min-width: min(280px, 80vw);
+      0 8px 24px rgba(205, 0, 0, 0.18);
+    min-width: min(260px, 80vw);
     text-align: center;
   }
 
@@ -160,79 +166,78 @@
     flex: 1 1 auto;
     min-height: 0;
     width: 100%;
-    max-width: 1200px;
+    max-width: 1400px;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: clamp(10px, 2vh, 24px);
+    gap: clamp(6px, 1.2vh, 14px);
   }
 
   .winners-count {
     color: #4e4c4c;
-    font-size: clamp(14px, 2.4vh, 26px);
+    font-size: clamp(13px, 2vh, 22px);
     font-weight: 600;
+    flex-shrink: 0;
   }
 
+  /* Equal-height rows (1fr) so cards always align in a clean grid even
+     when names wrap onto two lines. Padding-block kept small so the
+     grid actually fills the available area. */
   .winners-grid {
     flex: 1 1 auto;
     min-height: 0;
     width: 100%;
     display: grid;
-    place-content: center;
-    align-items: start;
-    gap: clamp(12px, 2.4vh, 28px);
-    padding: clamp(4px, 1vh, 12px);
-    overflow: auto;
+    grid-auto-rows: 1fr;
+    gap: clamp(6px, 1.2vh, 14px);
+    padding: clamp(2px, 0.6vh, 8px);
+    box-sizing: border-box;
+    overflow-y: auto;
   }
 
-  /* Tier-based sizing keeps winners filling the visible area without
-     scroll for typical 1-12 person draws. */
-  .winners-grid.size-xl {
+  .tier-1 {
     grid-template-columns: 1fr;
+    place-items: center;
   }
-  .winners-grid.size-lg {
-    grid-template-columns: repeat(auto-fit, minmax(min(260px, 80vw), 1fr));
-  }
-  .winners-grid.size-md {
-    grid-template-columns: repeat(auto-fit, minmax(min(200px, 40vw), 1fr));
-  }
-  .winners-grid.size-sm {
-    grid-template-columns: repeat(auto-fit, minmax(min(160px, 30vw), 1fr));
-  }
-  .winners-grid.size-xs {
-    grid-template-columns: repeat(auto-fit, minmax(min(120px, 22vw), 1fr));
-  }
+  .tier-2 { grid-template-columns: repeat(2, 1fr); }
+  .tier-3 { grid-template-columns: repeat(3, 1fr); }
+  .tier-4 { grid-template-columns: repeat(4, 1fr); }
+  .tier-5 { grid-template-columns: repeat(5, 1fr); }
+  .tier-6 { grid-template-columns: repeat(6, 1fr); }
 
   .winner-card {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     align-items: center;
-    gap: clamp(6px, 1.2vh, 12px);
-    animation: card-pop 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
-    padding: clamp(6px, 1.2vh, 12px);
-    background: rgba(255, 255, 255, 0.55);
-    backdrop-filter: blur(8px);
-    border-radius: clamp(14px, 2vh, 24px);
-    border: 1px solid rgba(205, 0, 0, 0.1);
-    box-shadow: 0 8px 24px rgba(205, 0, 0, 0.12);
+    gap: clamp(6px, 1.2vw, 14px);
+    padding: clamp(6px, 1vh, 12px) clamp(8px, 1.4vw, 16px);
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: clamp(10px, 1.6vh, 18px);
+    border: 1px solid rgba(205, 0, 0, 0.18);
+    box-shadow: 0 6px 18px rgba(205, 0, 0, 0.16);
+    animation: card-pop 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) backwards;
+    height: 100%;
+    box-sizing: border-box;
+    min-width: 0;
+    overflow: hidden;
   }
 
   .winner-avatar {
-    --size: var(--avatar-size, 110px);
-    width: var(--size);
-    height: var(--size);
+    flex: 0 0 auto;
+    height: 72%;
+    aspect-ratio: 1;
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     color: #fff;
     font-weight: 800;
-    font-size: calc(var(--size) * 0.32);
-    border: 4px solid #fff;
-    box-shadow: 0 0 24px rgba(255, 215, 0, 0.7),
-      0 8px 18px rgba(205, 0, 0, 0.3),
-      inset 0 -8px 16px rgba(0, 0, 0, 0.18),
-      inset 0 8px 14px rgba(255, 255, 255, 0.35);
+    font-size: clamp(11px, 1.8vh, 26px);
+    border: clamp(2px, 0.4vh, 4px) solid #fff;
+    box-shadow: 0 0 16px rgba(255, 215, 0, 0.55),
+      0 4px 12px rgba(205, 0, 0, 0.25),
+      inset 0 -6px 12px rgba(0, 0, 0, 0.18),
+      inset 0 6px 10px rgba(255, 255, 255, 0.35);
     overflow: hidden;
     animation: glow 1.6s ease-in-out infinite alternate;
   }
@@ -243,42 +248,48 @@
     object-fit: cover;
   }
 
-  .size-xl .winner-avatar {
-    --avatar-size: clamp(140px, 28vh, 240px);
-  }
-  .size-lg .winner-avatar {
-    --avatar-size: clamp(100px, 18vh, 180px);
-  }
-  .size-md .winner-avatar {
-    --avatar-size: clamp(80px, 14vh, 130px);
-  }
-  .size-sm .winner-avatar {
-    --avatar-size: clamp(64px, 10vh, 100px);
-  }
-  .size-xs .winner-avatar {
-    --avatar-size: clamp(48px, 8vh, 80px);
-  }
-
   .winner-name {
+    flex: 1 1 auto;
+    min-width: 0;
     background: #cd0000;
     color: #fff;
     border-radius: 999px;
-    padding: clamp(4px, 0.8vh, 10px) clamp(14px, 2.4vw, 26px);
-    font-size: clamp(14px, 2.2vh, 22px);
+    padding: clamp(3px, 0.6vh, 8px) clamp(8px, 1.2vw, 16px);
+    font-size: clamp(11px, 1.7vh, 22px);
     font-weight: 800;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.04em;
     box-shadow: inset -2px -3px 0 rgba(0, 0, 0, 0.25),
-      0 6px 14px rgba(205, 0, 0, 0.3);
-    max-width: 100%;
+      0 4px 10px rgba(205, 0, 0, 0.3);
     white-space: normal;
     word-break: break-word;
     text-align: center;
-    line-height: 1.25;
+    line-height: 1.2;
+    /* Cap to ~3 lines so a very long name can't blow past the card */
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
   }
 
-  .size-xl .winner-name {
-    font-size: clamp(20px, 4vh, 36px);
-    padding: clamp(8px, 1.2vh, 14px) clamp(20px, 3vw, 40px);
+  /* Single-winner gets the dramatic stacked layout */
+  .tier-1 .winner-card {
+    flex-direction: column;
+    gap: clamp(12px, 2.4vh, 22px);
+    padding: clamp(16px, 3vh, 30px);
+    width: min(440px, 82vw);
+    height: auto;
+    align-self: center;
+  }
+  .tier-1 .winner-avatar {
+    height: clamp(120px, 26vh, 220px);
+    width: clamp(120px, 26vh, 220px);
+    aspect-ratio: 1;
+    font-size: clamp(40px, 8vh, 72px);
+  }
+  .tier-1 .winner-name {
+    font-size: clamp(20px, 3.6vh, 36px);
+    padding: clamp(8px, 1.4vh, 14px) clamp(20px, 3vw, 40px);
+    -webkit-line-clamp: 4;
   }
 
   .next-btn {
@@ -286,31 +297,32 @@
     color: #cd0000;
     background: transparent;
     border: 0;
-    font-size: clamp(18px, 2.6vh, 28px);
+    font-size: clamp(16px, 2.4vh, 26px);
     font-weight: 800;
     display: flex;
     align-items: center;
     justify-content: center;
     gap: 12px;
-    padding: clamp(6px, 1vh, 12px) 24px;
+    padding: clamp(4px, 0.8vh, 10px) 24px;
     transition: transform 0.2s ease;
+    cursor: pointer;
   }
   .next-btn:hover {
     transform: translateX(4px);
   }
   .next-btn img {
-    width: clamp(20px, 2.6vh, 28px);
+    width: clamp(18px, 2.4vh, 26px);
     height: auto;
   }
 
   @keyframes card-pop {
     0% {
       opacity: 0;
-      transform: translateY(30px) scale(0.7);
+      transform: translateY(20px) scale(0.85);
     }
     60% {
       opacity: 1;
-      transform: translateY(-4px) scale(1.06);
+      transform: translateY(-3px) scale(1.04);
     }
     100% {
       opacity: 1;
@@ -320,32 +332,50 @@
 
   @keyframes glow {
     0% {
-      box-shadow: 0 0 20px rgba(255, 215, 0, 0.5),
-        0 8px 18px rgba(205, 0, 0, 0.3),
-        inset 0 -8px 16px rgba(0, 0, 0, 0.18),
-        inset 0 8px 14px rgba(255, 255, 255, 0.35);
+      box-shadow: 0 0 14px rgba(255, 215, 0, 0.45),
+        0 4px 12px rgba(205, 0, 0, 0.25),
+        inset 0 -6px 12px rgba(0, 0, 0, 0.18),
+        inset 0 6px 10px rgba(255, 255, 255, 0.35);
     }
     100% {
-      box-shadow: 0 0 36px rgba(255, 215, 0, 0.95),
-        0 8px 22px rgba(205, 0, 0, 0.45),
-        inset 0 -8px 16px rgba(0, 0, 0, 0.18),
-        inset 0 8px 14px rgba(255, 255, 255, 0.35);
+      box-shadow: 0 0 26px rgba(255, 215, 0, 0.85),
+        0 4px 14px rgba(205, 0, 0, 0.4),
+        inset 0 -6px 12px rgba(0, 0, 0, 0.18),
+        inset 0 6px 10px rgba(255, 255, 255, 0.35);
     }
+  }
+
+  /* Tablets / small laptops: drop one column for tier-3+ so cards keep
+     enough horizontal room for the name beside the avatar. */
+  @media (max-width: 1024px) {
+    .tier-4 { grid-template-columns: repeat(3, 1fr); }
+    .tier-5 { grid-template-columns: repeat(4, 1fr); }
+    .tier-6 { grid-template-columns: repeat(5, 1fr); }
   }
 
   @media (max-width: 768px) {
     .deco {
-      max-height: 16vh;
-      opacity: 0.4;
+      max-height: 12vh;
+      opacity: 0.35;
     }
+    .tier-3 { grid-template-columns: repeat(2, 1fr); }
+    .tier-4 { grid-template-columns: repeat(2, 1fr); }
+    .tier-5 { grid-template-columns: repeat(3, 1fr); }
+    .tier-6 { grid-template-columns: repeat(3, 1fr); }
   }
 
   @media (max-width: 480px) {
     .deco {
       display: none;
     }
-    .winners-grid {
-      gap: 12px;
+    .tier-2 { grid-template-columns: 1fr; }
+    .tier-3,
+    .tier-4 {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .tier-5,
+    .tier-6 {
+      grid-template-columns: repeat(2, 1fr);
     }
   }
 </style>


### PR DESCRIPTION
## Summary

修截圖中「20 人得獎、卡片擠成一團、最下排被裝飾蓋掉」的問題。原本用 `auto-fit, minmax(...)` + 名字 wrap，導致長名字（例如「黃品叡 (Paul) -RD- SRE」）把卡片撐得超高，網格就崩成不同高度的階梯狀；加上紅色裝飾與卡片半透明重疊看起來像被遮住。

**改法：**

- **水平卡片**：圓形頭像左、紅底白字徽章右、徽章用 `flex: 1 1 auto` 撐滿剩餘寬度。名字加 `-webkit-line-clamp: 3` 防超長失控。
- **固定欄數的 grid**：依得獎人數分 6 階，欄數明確（1/2/3/4/5/6），`grid-auto-rows: 1fr` 讓每張卡片高度一致，再也不會階梯。
  - ≤1 → 1 col（單張大卡，垂直排版的 grand prize 樣式保留）
  - ≤4 → 2 col
  - ≤9 → 3 col
  - ≤16 → 4 col
  - ≤25 → 5 col（截圖的 20 人會變 5×4 整齊）
  - 26+ → 6 col
- **RWD**：1024px 以下各階減 1 欄、768px 以下再減、480px 以下最多 2 欄
- **裝飾收斂**：兔子 `max-height` 18vh、opacity 0.6；bg-circle opacity 0.5。卡片背景從 `rgba(255,255,255,0.55)` 提到 `0.92`，紅色背景不會穿透到卡片內

## Test plan

- [ ] 抽 1 人：grand prize 大卡置中
- [ ] 抽 5 人：3 欄 × 2 列
- [ ] 抽 12 人：4 欄 × 3 列
- [ ] 抽 20 人（截圖 case）：5 欄 × 4 列、整齊不階梯
- [ ] 名字含長串（例 `Christopher Liu`、`真利子あずき (Azusa Mariko)_JP CS`）：徽章內換行最多 3 行，不會撐破卡片
- [ ] iPhone 直立：tier-5 自動降到 3 欄，名字仍可讀
- [ ] iPad / 1366×768 筆電：1024px breakpoint 減一欄、cards 寬度足夠

https://claude.ai/code/session_012K3Ypa9Lp5XWjerDpRynSk

---
_Generated by [Claude Code](https://claude.ai/code/session_012K3Ypa9Lp5XWjerDpRynSk)_